### PR TITLE
Added support for a :children_count counter_cache column

### DIFF
--- a/lib/awesome_nested_set.rb
+++ b/lib/awesome_nested_set.rb
@@ -59,11 +59,20 @@ module CollectiveIdea #:nodoc:
             include InstanceMethods
             extend Columns
             extend ClassMethods
-            
-            belongs_to :parent, :class_name => self.base_class.to_s,
-              :foreign_key => parent_column_name
-            has_many :children, :class_name => self.base_class.to_s,
-              :foreign_key => parent_column_name, :order => quoted_left_column_name
+
+            belongs_to_options = {
+              :class_name => self.base_class.to_s,
+              :foreign_key => parent_column_name,
+            }
+            belongs_to_options[:counter_cache] = 'children_count' if acts_as_nested_set_options[:counter_cache]
+            belongs_to :parent, belongs_to_options
+
+            has_many_options = {
+              :class_name => self.base_class.to_s,
+              :foreign_key => parent_column_name,
+              :order => quoted_left_column_name,
+            }
+            has_many :children, has_many_options
 
             attr_accessor :skip_before_destroy
           

--- a/test/awesome_nested_set_test.rb
+++ b/test/awesome_nested_set_test.rb
@@ -14,6 +14,9 @@ end
 class RenamedColumns < ActiveRecord::Base
   acts_as_nested_set :parent_column => 'mother_id', :left_column => 'red', :right_column => 'black'
 end
+class Thing < ActiveRecord::Base
+  acts_as_nested_set :counter_cache => true
+end
 
 class AwesomeNestedSetTest < TestCaseClass
 
@@ -798,4 +801,30 @@ class AwesomeNestedSetTest < TestCaseClass
   ensure
     Category.after_save_callback_chain.pop
   end
+
+
+  def test_cached_column
+    note1 = things(:parent1)
+    assert_equal 2, note1.children.count
+  end
+
+  def test_cached_column_on_create
+    ActiveRecord::Base.logger.info 'FOO'
+    note1 = things(:parent1)
+    assert_equal 2, note1.children.count
+    assert_equal 2, note1[:children_count]
+    note1.children.create :body=>'Child 3'
+    assert_equal 3, note1.children.count
+    note1.reload; assert_equal 3, note1[:children_count]
+  end
+
+  def test_cached_column_on_destroy
+    note1 = things(:parent1)
+    assert_equal 2, note1.children.count
+    assert_equal 2, note1[:children_count]
+    note1.children.last.destroy
+    assert_equal 1, note1.children.count
+    note1.reload; assert_equal 1, note1[:children_count]
+  end
+
 end

--- a/test/db/schema.rb
+++ b/test/db/schema.rb
@@ -27,4 +27,12 @@ ActiveRecord::Schema.define(:version => 0) do
     t.column :red, :integer
     t.column :black, :integer
   end
+
+  create_table :things, :force => true do |t|
+    t.column :body, :text
+    t.column :parent_id, :integer
+    t.column :lft, :integer
+    t.column :rgt, :integer
+    t.column :children_count, :integer
+  end
 end

--- a/test/fixtures/things.yml
+++ b/test/fixtures/things.yml
@@ -1,0 +1,27 @@
+parent1:
+  id: 1
+  body: Top Level
+  lft: 1
+  rgt: 10
+  children_count: 2
+child_1:
+  id: 2
+  body: Child 1
+  parent_id: 1
+  lft: 2
+  rgt: 3
+  children_count: 0
+child_2:
+  id: 3
+  body: Child 2
+  parent_id: 1
+  lft: 4
+  rgt: 7
+  children_count: 0
+child_2_1:
+  id: 4
+  body: Child 2.1
+  parent_id: 3
+  lft: 8
+  rgt: 9
+  children_count: 0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,5 +25,5 @@ class TestCaseClass #:nodoc:
   self.use_transactional_fixtures = true
   self.use_instantiated_fixtures  = false
   
-  fixtures :categories, :notes, :departments
+  fixtures :categories, :notes, :departments, :things
 end


### PR DESCRIPTION
I needed this for performance reasons, and so I banged out a quick solution.  This should also close issue #36.
Tests are included... let me know if you see anything amiss.
Thanks!
