### PR TITLE
root method can return non-root elements

### DIFF
--- a/lib/awesome_nested_set.rb
+++ b/lib/awesome_nested_set.rb
@@ -298,7 +298,7 @@ module CollectiveIdea #:nodoc:
 
         # Returns root
         def root
-          self_and_ancestors.find(:first)
+          self_and_ancestors.find(:first, :conditions => {parent_column_name => nil})
         end
 
         # Returns the array of all parents and self


### PR DESCRIPTION
Very minor fix... adding the condition to the root method that the parent_column_name must be nil.  If you look at the diff it is very easy to see that the current version of awesome_nested_set can return non-root elements when calling root on an element.  It works the vast majority of the time because MySQL generally returns rows in the order they were inserted, and root nodes are generally inserted before their descendants.
