### PR TITLE
use define_model_callbacks instead of define_callbacks

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -88,7 +88,7 @@ module CollectiveIdea #:nodoc:
         scope :roots, where(parent_column_name => nil).order(quoted_left_column_name)
         scope :leaves, where("#{quoted_right_column_name} - #{quoted_left_column_name} = 1").order(quoted_left_column_name)
 
-        define_callbacks :move, :terminator => "result == false"
+        define_model_callbacks :move
       end
 
       module Model


### PR DESCRIPTION
ActiveSupport::Callbacks.define_callbacks doesn't define the class
macros to create callbacks (anymore?). This means that in 2.0.0,
before_move, after_move, and around_move are missing.

ActiveModel::Callbacks.define_model_callbacks handles defining the
macros, and as a bonus adds the `:terminator` option itself.
