### PR TITLE
Fix up usage of deprecated code (class_inheritable attributes).

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -51,8 +51,8 @@ module CollectiveIdea #:nodoc:
           options[:scope] = "#{options[:scope]}_id".intern
         end
 
-        write_inheritable_attribute :acts_as_nested_set_options, options
-        class_inheritable_reader :acts_as_nested_set_options
+        class_attribute :acts_as_nested_set_options
+        self.acts_as_nested_set_options = options
 
         include CollectiveIdea::Acts::NestedSet::Model
         include Columns


### PR DESCRIPTION
This avoids the following warnings:

DEPRECATION WARNING: class_inheritable_attribute is deprecated, please use class_attribute method instead. Notice their behavior are slightly different, so refer to class_attribute documentation first. (called from class:Page at /code/parndt/Refinery/pages/app/models/refinery/page.rb:62)
DEPRECATION WARNING: class_inheritable_attribute is deprecated, please use class_attribute method instead. Notice their behavior are slightly different, so refer to class_attribute documentation first. (called from class:Page at /code/parndt/Refinery/pages/app/models/page.rb:60)
