### PR TITLE
Modify helper to allow using array of objects as argument

### DIFF
--- a/lib/awesome_nested_set/helper.rb
+++ b/lib/awesome_nested_set/helper.rb
@@ -21,8 +21,12 @@ module CollectiveIdea #:nodoc:
         #     }) %>
         #
         def nested_set_options(class_or_item, mover = nil)
-          class_or_item = class_or_item.roots if class_or_item.is_a?(Class)
-          items = Array(class_or_item)
+          if class_or_item.is_a? Array
+            items = class_or_item.reject { |e| !e.root? }
+          else
+            class_or_item = class_or_item.roots if class_or_item.is_a?(Class)
+            items = Array(class_or_item)
+          end
           result = []
           items.each do |root|
             result += root.self_and_descendants.map do |i|

--- a/spec/awesome_nested_set/helper_spec.rb
+++ b/spec/awesome_nested_set/helper_spec.rb
@@ -8,7 +8,7 @@ describe "Helper" do
   end
 
   describe "nested_set_options" do
-    def test_nested_set_options
+    it "test_nested_set_options" do
       expected = [
         [" Top Level", 1],
         ["- Child 1", 2],
@@ -23,7 +23,7 @@ describe "Helper" do
       actual.should == expected
     end
 
-    def test_nested_set_options_with_mover
+    it "test_nested_set_options_with_mover" do
       expected = [
         [" Top Level", 1],
         ["- Child 1", 2],
@@ -31,6 +31,34 @@ describe "Helper" do
         [" Top Level 2", 6]
       ]
       actual = nested_set_options(Category, categories(:child_2)) do |c|
+        "#{'-' * c.level} #{c.name}"
+      end
+      actual.should == expected
+    end
+
+    it "test_nested_set_options_with_array_as_argument_without_mover" do
+      expected = [
+        [" Top Level", 1],
+        ["- Child 1", 2],
+        ['- Child 2', 3],
+        ['-- Child 2.1', 4],
+        ['- Child 3', 5],
+        [" Top Level 2", 6]
+      ]
+      actual = nested_set_options(Category.all) do |c|
+        "#{'-' * c.level} #{c.name}"
+      end
+      actual.should == expected
+    end
+
+    it "test_nested_set_options_with_array_as_argument_with_mover" do
+      expected = [
+        [" Top Level", 1],
+        ["- Child 1", 2],
+        ['- Child 3', 5],
+        [" Top Level 2", 6]
+      ]
+      actual = nested_set_options(Category.all, categories(:child_2)) do |c|
         "#{'-' * c.level} #{c.name}"
       end
       actual.should == expected


### PR DESCRIPTION
I modified the nested_set_options method to be able to use an array as its argument, so it can use any array of nested object, ex. nested categories from a particular company

``` ruby
nested_set_options(Company.first.categories)
```
