### PR TITLE
Fix .all_roots_valid? to work with Postgres.

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -140,7 +140,7 @@ module CollectiveIdea #:nodoc:
           # Wrapper for each_root_valid? that can deal with scope.
           def all_roots_valid?
             if acts_as_nested_set_options[:scope]
-              roots.group(scope_column_names).group_by{|record| scope_column_names.collect{|col| record.send(col.to_sym)}}.all? do |scope, grouped_roots|
+              roots.group_by {|record| scope_column_names.collect {|col| record.send(col.to_sym) } }.all? do |scope, grouped_roots|
                 each_root_valid?(grouped_roots)
               end
             else


### PR DESCRIPTION
.all_roots_valid? was using SQL to group and then doing an additional
group_by to group data; however, `roots.group` doesn't work with
Postgres and was raising an ActiveRecord::StatementInvalid because of
how Postgres handles the GROUP BY clause. This removes the group from
SQL completely.

Closes #88
