### PR TITLE
Oracle Compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,6 @@ gem 'pg'
 gem 'sqlite3', :platform => :ruby
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'rspec-rails',        '~> 2.6'
+# Add Oracle Adapters
+gem 'ruby-oci8'
+gem 'activerecord-oracle_enhanced-adapter'

--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -110,8 +110,11 @@ module CollectiveIdea #:nodoc:
             left_and_rights_valid? && no_duplicates_for_columns? && all_roots_valid?
           end
 
-          def left_and_rights_valid?
-            joins("LEFT OUTER JOIN #{quoted_table_name} AS parent ON " +
+          def left_and_rights_valid?  
+            ## AS clause not supported in Oracle in FROM clause for aliasing table name
+            joins("LEFT OUTER JOIN #{quoted_table_name}" + 
+                (connection.adapter_name.match(/Oracle/).nil? ?  " AS " : " ") + 
+                "parent ON " +
                 "#{quoted_table_name}.#{quoted_parent_column_name} = parent.#{primary_key}").
             where(
                 "#{quoted_table_name}.#{quoted_left_column_name} IS NULL OR " +

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -611,7 +611,15 @@ describe "AwesomeNestedSet" do
   end
 
   it "quoting_of_multi_scope_column_names" do
-    ["\"notable_id\"", "\"notable_type\""].should == Note.quoted_scope_column_names
+    ## Proper Array Assignment for different DBs as per their quoting column behavior   
+    if Note.connection.adapter_name.match(/Oracle/)
+      expected_quoted_scope_column_names = ["\"NOTABLE_ID\"", "\"NOTABLE_TYPE\""]
+    elsif Note.connection.adapter_name.match(/Mysql/)
+      expected_quoted_scope_column_names = ["`notable_id`", "`notable_type`"]
+    else
+      expected_quoted_scope_column_names = ["\"notable_id\"", "\"notable_type\""]
+    end
+    expected_quoted_scope_column_names.should == Note.quoted_scope_column_names
   end
 
   it "equal_in_same_scope" do

--- a/spec/db/database.yml
+++ b/spec/db/database.yml
@@ -14,5 +14,12 @@ mysql:
   adapter: mysql2
   host: localhost
   username: root
-  password:
+  password: 
   database: awesome_nested_set_plugin_test
+## Add DB Configuration to run Oracle tests
+oracle:
+  adapter: oracle_enhanced
+  host: localhost
+  username: awesome_nested_set_dev
+  password: 
+  database: xe


### PR DESCRIPTION
1. SQL Used in FUNCTION - left_and_rights_valid?  IN FILE - lib/awesome_nested_set/awesome_nested_set.rb is fixed to not include AS clause in SQL's FROM clause for table aliasing (_AS clause not supported in Oracle in FROM clause for aliasing table name_)
2. Sample Oracle Adapter configuration added in database.yml
3. Gemfile updated to include oracle specific ruby gems.
4. quoting_of_multi_scope_column_names spec in spec/awesome_nested_set_spec.rb is enhanced to include proper strings as per DB connection.
5. multi_scoped_all_roots_valid? spec in spec/awesome_nested_set_spec.rb is failing due to limitation of Oracle's GROUP BY clause. For details, please refer [Oracle GROUP BY Clause Limitation](http://sqlzoo.net/howto/source/u.cgi/err979/oracle) .
6. multi_scoped_rebuild spec in spec/awesome_nested_set_spec.rb is failing due to no support of CLOB datatype in Oracle. For details and application specific solution, please refer [Changing Oracle CLOBs to VARCHAR2s](http://snippets.dzone.com/posts/show/3022) .
