### PR TITLE
Avoid default_scopes (that may change SQL order)

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -394,7 +394,7 @@ module CollectiveIdea #:nodoc:
             options[:conditions] = scopes.inject({}) do |conditions,attr|
               conditions.merge attr => self[attr]
             end unless scopes.empty?
-            self.class.base_class.scoped options
+            self.class.base_class.unscoped.scoped options
           end
 
           def store_new_parent

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -55,7 +55,7 @@ describe "AwesomeNestedSet" do
       Broken.create!
     end
   end
-  
+
   it "quoted_left_column_name" do
     quoted = Default.connection.quote_column_name('lft')
     Default.quoted_left_column_name.should == quoted
@@ -836,6 +836,21 @@ describe "AwesomeNestedSet" do
 
       root.before_remove.should == child
       root.after_remove.should  == child
+    end
+  end
+
+  describe 'creating roots with a default scope ordering' do
+    it "assigns rgt and lft correctly" do
+      alpha = Order.create(:name => 'Alpha')
+      gamma = Order.create(:name => 'Gamma')
+      omega = Order.create(:name => 'Omega')
+
+      alpha.lft.should == 1
+      alpha.rgt.should == 2
+      gamma.lft.should == 3
+      gamma.rgt.should == 4
+      omega.lft.should == 5
+      omega.rgt.should == 6
     end
   end
 end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -35,8 +35,15 @@ ActiveRecord::Schema.define(:version => 0) do
     t.column :rgt, :integer
     t.column :children_count, :integer
   end
-  
+
   create_table :brokens, :force => true do |t|
+    t.column :name, :string
+    t.column :parent_id, :integer
+    t.column :lft, :integer
+    t.column :rgt, :integer
+  end
+
+  create_table :orders, :force => true do |t|
     t.column :name, :string
     t.column :parent_id, :integer
     t.column :lft, :integer

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -70,3 +70,9 @@ end
 class Broken < ActiveRecord::Base
   acts_as_nested_set
 end
+
+class Order < ActiveRecord::Base
+  acts_as_nested_set
+
+  default_scope order(:name)
+end


### PR DESCRIPTION
Heya Phil

Just hit a problem with awesome_nested_set - when there's a default scope setting up an ORDER clause, obtaining the last rgt value (for new records) doesn't work because the "rgt DESC" is appended to the existing ORDER clause, instead of overwriting it.

Ensuring the query is unscoped explicitly fixes the problem. And you get a spec thrown in for free! ;)
