### PR TITLE
A more robust leaf? function

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -243,7 +243,7 @@ module CollectiveIdea #:nodoc:
           end
 
           def leaf?
-            !new_record? && right - left == 1
+						!new_record? && !(right.nil? || left.nil?) && right - left == 1
           end
 
           # Returns true is this is a child node


### PR DESCRIPTION
The leaf? function dies if lft or rgt are nil.  Here is a suggested fix.
