### PR TITLE
Improve performance of self_and_descendants

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -336,7 +336,7 @@ module CollectiveIdea #:nodoc:
         # Returns a set of itself and all of its nested children
         def self_and_descendants
           nested_set_scope.where([
-            "#{self.class.quoted_table_name}.#{quoted_left_column_name} >= ? AND #{self.class.quoted_table_name}.#{quoted_left_column_name} <= ?", left, right
+            "#{self.class.quoted_table_name}.#{quoted_left_column_name} >= ? AND #{self.class.quoted_table_name}.#{quoted_left_column_name} < ?", left, right
             # using _left_ for both sides here lets us benefit from an index on that column if one exists
           ])
         end


### PR DESCRIPTION
This modified version of self_and_descendants is semantically equivalent and passes all tests, but it uses only the lft field of the records it queries, which means it can benefit from an index on that field if one exists on your table.
