### PR TITLE
nested_set helpers and #level query counts

### DIFF
--- a/lib/awesome_nested_set/helper.rb
+++ b/lib/awesome_nested_set/helper.rb
@@ -30,7 +30,7 @@ module CollectiveIdea #:nodoc:
           end
           result = []
           items.each do |root|
-            result += root.self_and_descendants.map do |i|
+            result += root.class.associate_parents(root.self_and_descendants).map do |i|
               if mover.nil? || mover.new_record? || mover.move_possible?(i)
                 [yield(i), i.id]
               end
@@ -66,7 +66,7 @@ module CollectiveIdea #:nodoc:
           result = []
           children = []
           items.each do |root|
-            root.self_and_descendants.map do |i|
+            root.class.associate_parents(root.self_and_descendants).map do |i|
               if mover.nil? || mover.new_record? || mover.move_possible?(i)
                 if !i.leaf?
                   children.sort_by! &order


### PR DESCRIPTION
The patch reduces the number of queries fired by the canonical usage of the `level` method in the `nested_set` helpers. The current status is 1 ancestors `count(*)` query for each item in the collection, the patch typically eliminates all the extra queries.

Don't know if this should be tested... perhaps by copying over something like `assert_queries` from Rails' `ActiveRecord::TestCase`?
