### PR TITLE
Optimize select and lock in destroy_descendants

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -533,7 +533,12 @@ module CollectiveIdea #:nodoc:
           return if right.nil? || left.nil? || skip_before_destroy
 
           in_tenacious_transaction do
-            reload_nested_set
+            begin
+              reload_nested_set
+            rescue ActiveRecord::RecordNotFound
+              return
+            end
+
             # select the rows in the model that extend past the deletion point and apply a lock
             nested_set_scope.where(["#{quoted_left_column_name} >= ?", left]).
                                   select(id).lock(true)


### PR DESCRIPTION
...at extend past the deletion point.  Same as issue reported in #119
