### PR TITLE
Performance Issue with move_to

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -655,21 +655,21 @@ module CollectiveIdea #:nodoc:
                 else          target[parent_column_name]
               end
 
-              where_statement = ["#{quoted_left_column_name} <> CASE " +
+              where_statement = ["not (#{quoted_left_column_name} = CASE " +
                                      "WHEN #{quoted_left_column_name} BETWEEN :a AND :b " +
                                      "THEN #{quoted_left_column_name} + :d - :b " +
                                      "WHEN #{quoted_left_column_name} BETWEEN :c AND :d " +
                                      "THEN #{quoted_left_column_name} + :a - :c " +
                                      "ELSE #{quoted_left_column_name} END AND " +
-                                     "#{quoted_right_column_name} <> CASE " +
+                                     "#{quoted_right_column_name} = CASE " +
                                      "WHEN #{quoted_right_column_name} BETWEEN :a AND :b " +
                                      "THEN #{quoted_right_column_name} + :d - :b " +
                                      "WHEN #{quoted_right_column_name} BETWEEN :c AND :d " +
                                      "THEN #{quoted_right_column_name} + :a - :c " +
                                      "ELSE #{quoted_right_column_name} END AND " +
-                                     "#{quoted_parent_column_name} <> CASE " +
+                                     "#{quoted_parent_column_name} = CASE " +
                                      "WHEN #{self.class.base_class.primary_key} = :id THEN :new_parent " +
-                                     "ELSE #{quoted_parent_column_name} END" ,
+                                     "ELSE #{quoted_parent_column_name} END)" ,
                                  {:a => a, :b => b, :c => c, :d => d, :id => self.id, :new_parent => new_parent}    ]
 
 


### PR DESCRIPTION
move_to creates performance issue on large trees. After inserting a child record on a tree, move_to performs a update query on each record in a given scope. Doing several inserts will update the left rights and parents for every record in the tree. I modified move_to to add a constraint query to limit the records updated to only those records where left, right , or parent_id are changed.

I think the existing test cover this case but kickit back if you think a additional test is necessary.

Thanks
Eric Smith
