### PR TITLE
add license information to the gemspec

### DIFF
--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails', '~> 2.12'
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'combustion', '>= 0.3.3'
+  s.license = "MIT"
 end


### PR DESCRIPTION
This way it can be queried using the rubygems.org API
