### PR TITLE
remove some wordy lines of code and changed #move_to_root implementation

### DIFF
--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -433,8 +433,8 @@ describe "AwesomeNestedSet" do
     categories(:child_2).parent.should be_nil
     categories(:child_2).level.should == 0
     categories(:child_2_1).level.should == 1
-    categories(:child_2).left.should == 1
-    categories(:child_2).right.should == 4
+    categories(:child_2).left.should == 7
+    categories(:child_2).right.should == 10
     Category.valid?.should be_true
   end
 


### PR DESCRIPTION
Hi,

I did a slight refactoring on the code.
- the `where` clause added in 5395e63451610316669cdf803c9cb526f8464a7b should be now more readable
- `node.move_to_root` is now implemented as `node.move_to_right_of(node.root)`, because in the current implementation node.lft is set to 1, which can cause a performance issue (namely: it updates all records!) if you have many roots and you want to move one subtree of the last root to root level
- all `move_to` variants are able to take record objects too, so the comments, that the can't are removed.

I hope that helps.

Best regards

Jan
