### PR TITLE
Delegate connection to class

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -105,7 +105,7 @@ module CollectiveIdea #:nodoc:
         extend ActiveSupport::Concern
 
         included do
-          delegate :quoted_table_name, :to => self
+          delegate :quoted_table_name, :connection, :to => self
         end
 
         module ClassMethods


### PR DESCRIPTION
Rails 4 has deprecated the instance connection method, this adds a delegation method back to skip the deprecation warning

This fixes #180
