### PR TITLE
Issue #166 Oracle does not support locks in subquery

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -540,7 +540,8 @@ module CollectiveIdea #:nodoc:
 
         # on creation, set automatically lft and rgt to the end of the tree
         def set_default_left_and_right
-          highest_right_row = nested_set_scope(:order => "#{quoted_right_column_full_name} desc").limit(1).lock(true).first
+          highest_right_row = nested_set_scope(:order => "#{quoted_right_column_full_name} desc").first
+          highest_right_row && highest_right_row.lock!
           maxright = highest_right_row ? (highest_right_row[right_column_name] || 0) : 0
           # adds the new node to the right of all existing nodes
           self[left_column_name] = maxright + 1


### PR DESCRIPTION
Since Oracle doesn't allow you to lock a row in a subquery, this will get the row and lock it. I ran the tests against Oracle, MySQL, and SQLite.

There is still one broken test on Oracle that was present before this change. Line 767 of awesome_nested_set_spec.rb fails because oracle won't let you use a clob in a where clause (what it translates column type :text to). I suspect that is an issue that needs to be fixed in the adapter.
