### PR TITLE
Quote order_column_name 

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -72,7 +72,7 @@ module CollectiveIdea #:nodoc:
         has_many_children_options = {
           :class_name => self.base_class.to_s,
           :foreign_key => parent_column_name,
-          :order => order_column,
+          :order => quoted_order_column_name,
           :inverse_of => (:parent unless options[:polymorphic]),
         }
 
@@ -726,6 +726,10 @@ module CollectiveIdea #:nodoc:
 
         def quoted_scope_column_names
           scope_column_names.collect {|column_name| connection.quote_column_name(column_name) }
+        end
+
+        def quoted_order_column_name
+          connection.quote_column_name(order_column)
         end
 
         def quoted_left_column_full_name

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -81,6 +81,12 @@ describe "AwesomeNestedSet" do
     Default.new.quoted_depth_column_name.should == quoted
   end
 
+  it "quoted_order_column_name" do
+    quoted = Default.connection.quote_column_name('lft')
+    Default.quoted_order_column_name.should == quoted
+    Default.new.quoted_order_column_name.should == quoted
+  end
+
   it "left_column_protected_from_assignment" do
     lambda {
       Category.new.lft = 1


### PR DESCRIPTION
when using reserved words as `order_column_name` or as `left_column_name` the unquoted name will raise errors

```
ActiveRecord::StatementInvalid: Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1: SELECT `categories`.* FROM `categories`  WHERE `categories`.`parent_id` = 7 ORDER BY left
```
