### PR TITLE
Fix ordering for left_sibling

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -403,7 +403,7 @@ module CollectiveIdea #:nodoc:
         # Find the first sibling to the left
         def left_sibling
           siblings.where(["#{quoted_left_column_full_name} < ?", left]).
-                  order("#{quoted_left_column_full_name} DESC").last
+                  order("#{quoted_left_column_full_name}").last
         end
 
         # Find the first sibling to the right


### PR DESCRIPTION
When `default_scope -> { order :lft }` left_sibling works wrong.
