### PR TITLE
Fixed scope_for_rebuild, NULL values cannot be compared with SQL = operator

### DIFF
--- a/lib/awesome_nested_set/model/rebuildable.rb
+++ b/lib/awesome_nested_set/model/rebuildable.rb
@@ -22,7 +22,9 @@ module CollectiveIdea
             if acts_as_nested_set_options[:scope]
               scope = proc {|node|
                 scope_column_names.inject("") {|str, column_name|
-                  str << "AND #{connection.quote_column_name(column_name)} = #{connection.quote(node.send(column_name))} "
+                  column_value = node.send(column_name)
+                  cond = column_value.nil? ? "IS NULL" : "= #{connection.quote(column_value)}"
+                  str << "AND #{connection.quote_column_name(column_name)} #{cond} "
                 }
               }
             end


### PR DESCRIPTION
Scope columns can contain NULL values. This commit fixes regression introduced in version 3.  
