### PR TITLE
Modify associate_parents to add child objects to the parent#children collection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Modified associate_parents to add child objects to the parent#children collection [Tiago Moraes]
+
 2.1.6
 * Fixed rebuild! when there is a default_scope with order [Adrian Serafin]
 * Testing with stable bundler, ruby 2.0, MySQL and PostgreSQL [Philip Arndt]

--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -34,9 +34,16 @@ module CollectiveIdea #:nodoc:
 
               if !association.loaded? && parent
                 association.target = parent
-                association.set_inverse_instance(parent)
+                add_to_inverse_association(association, parent)
               end
             end
+          end
+
+          def add_to_inverse_association(association, record)
+            inverse_reflection = association.send(:inverse_reflection_for, record)
+            inverse = record.association(inverse_reflection.name)
+            inverse.target << association.owner
+            inverse.loaded!
           end
 
           def children_of(parent_id)

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -1086,4 +1086,20 @@ describe "AwesomeNestedSet" do
       OrderedCategory.order_column.should == 'name'
     end
   end
+
+  describe 'associate_parents' do
+    it 'assigns parent' do
+      root = Category.root
+      categories = root.self_and_descendants
+      categories = Category.associate_parents categories
+      expect(categories[1].parent).to be categories.first
+    end
+
+    it 'adds children on inverse of association' do
+      root = Category.root
+      categories = root.self_and_descendants
+      categories = Category.associate_parents categories
+      expect(categories[0].children.first).to be categories[1]
+    end
+  end
 end


### PR DESCRIPTION
Hello,
associate_parents currently calls `association.set_inverse_instance(parent)` but on the current version of activerecord doesn't support setting inverse has_many associations:

``` ruby
# NOTE - for now, we're only supporting inverse setting from belongs_to back onto
# has_one associations.
def invertible_for?(record)
  inverse = inverse_reflection_for(record)
  inverse && inverse.macro == :has_one
end
```

[belongs_to_association.rb line 72](https://github.com/rails/rails/blob/dfd7454683c0222bdb741753b76e8d68f5e73aef/activerecord/lib/active_record/associations/belongs_to_association.rb#L72)

I implemented this fix to not depend on activerecord's association#set_inverse_instance implementation.
