### PR TITLE
Relaxed activerecord dependency

### DIFF
--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.summary = %q{An awesome nested set implementation for Active Record}
   s.license = %q{MIT}
 
-  s.add_runtime_dependency 'activerecord', '~> 4.0.0'
+  s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 5'
 
   s.add_development_dependency 'rspec-rails', '~> 2.12'
   s.add_development_dependency 'rake', '~> 10'


### PR DESCRIPTION
I get the following error during `bundle update` with awesome_nested_set 3.0.0.rc.2 and actionpack-action_caching.

```
Bundler could not find compatible versions for gem "actionpack":
  In Gemfile:
    rails (= 4.0.0) ruby depends on
      actionpack (= 4.0.0) ruby

    actionpack-action_caching (~> 1.0.0) ruby depends on
      actionpack (4.0.1.rc3)
```

Relaxing the dependency of activerecord solved the issue for me.
