### PR TITLE
Bump to rc.3

### DIFF
--- a/lib/awesome_nested_set/version.rb
+++ b/lib/awesome_nested_set/version.rb
@@ -1,3 +1,3 @@
 module AwesomeNestedSet
-  VERSION = '3.0.0.rc.2' unless defined?(::AwesomeNestedSet::VERSION)
+  VERSION = '3.0.0.rc.3' unless defined?(::AwesomeNestedSet::VERSION)
 end


### PR DESCRIPTION
Need to do a new .rc.3 release so Spree can depend on this version, which has a relaxed Rails dependency.

This allows us to use a non-GH gem version and Rails 4.1.0.beta1.
