### PR TITLE
Optionally touch all ancestors on save

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -92,7 +92,8 @@ module CollectiveIdea #:nodoc:
                             :foreign_key => parent_column_name,
                             :counter_cache => acts_as_nested_set_options[:counter_cache],
                             :inverse_of => (:children unless acts_as_nested_set_options[:polymorphic]),
-                            :polymorphic => acts_as_nested_set_options[:polymorphic]
+                            :polymorphic => acts_as_nested_set_options[:polymorphic],
+                            :touch => acts_as_nested_set_options[:touch]
       end
 
       def acts_as_nested_set_default_options
@@ -103,7 +104,8 @@ module CollectiveIdea #:nodoc:
           :depth_column => 'depth',
           :dependent => :delete_all, # or :destroy
           :polymorphic => false,
-          :counter_cache => false
+          :counter_cache => false,
+          :touch => false
         }.freeze
       end
 


### PR DESCRIPTION
On the [belongs_to](http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-belongs_to) association there is the option to touch the associated object updating its `created_at`.

Exposing this option is extremely useful. The simplest example is if you use nested set as a nested navigational element and are fragment caching each node and then entire menu ([Russian doll caching](http://blog.remarkablelabs.com/2012/12/russian-doll-caching-cache-digests-rails-4-countdown-to-2013)). Editing any of the lower nodes your menu will not allow items further up to be re-cached. Setting `touch: true` on the `belongs_to` relationship will tell AcriveRecord to touch this, and this works all the way up the ancestry.

_note: This PR is against current 2-1-stable but will equally apply to ~> 3.0_
