### PR TITLE
v2.1.6: fix deleting a parent may lead to a stale object error

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -593,6 +593,8 @@ module CollectiveIdea #:nodoc:
               ["#{quoted_right_column_name} = (#{quoted_right_column_name} - ?)", diff]
             )
 
+            # Reload is needed because children may have updated their parent (self) during deletion.
+            reload
             # Don't allow multiple calls to destroy to corrupt the set
             self.skip_before_destroy = true
           end


### PR DESCRIPTION
Redmine Defect 7920
Attempted to update a stale object when copying a project
http://www.redmine.org/issues/7920

This revision passes Redmine test.
http://www.redmine.org/projects/redmine/repository/entry/trunk/test/unit/issue_nested_set_test.rb?rev=12679#L244

https://travis-ci.org/marutosi/redmine/jobs/17215987#L1979

<pre>
  1) Error:
test_destroy_parent_issue_updated_during_children_destroy(IssueNestedSetTest):
ActiveRecord::StaleObjectError: Attempted to destroy a stale object: Issue
    app/models/issue.rb:179:in `destroy'
    test/unit/issue_nested_set_test.rb:250:in `test_destroy_parent_issue_updated_during_children_destroy'
    test/unit/issue_nested_set_test.rb:249:in `test_destroy_parent_issue_updated_during_children_destroy'
</pre>
