### PR TITLE
v2.1.6: prevent DEPRECATION WARNING of Model.scoped on Rails 4.0

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -511,7 +511,9 @@ module CollectiveIdea #:nodoc:
           options[:conditions] = scopes.inject({}) do |conditions,attr|
             conditions.merge attr => self[attr]
           end unless scopes.empty?
-          self.class.base_class.unscoped.scoped options
+          ActiveSupport::Deprecation.silence do
+            self.class.base_class.unscoped.scoped(options)
+          end
         end
 
         def store_new_parent


### PR DESCRIPTION
DEPRECATION WARNING: Model.scoped is deprecated.
Please use Model.all instead.
