### PR TITLE
2-1-stable: fix ActiveRecord::StatementInvalid: Error: Column 'lft' in order clause is ambiguous

### DIFF
--- a/lib/awesome_nested_set/columns.rb
+++ b/lib/awesome_nested_set/columns.rb
@@ -51,6 +51,10 @@ module CollectiveIdea #:nodoc:
           connection.quote_column_name(order_column)
         end
 
+        def quoted_order_column_full_name
+          "#{quoted_table_name}.#{quoted_order_column_name}"
+        end
+
         def quoted_left_column_full_name
           "#{quoted_table_name}.#{quoted_left_column_name}"
         end

--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -72,7 +72,7 @@ module CollectiveIdea #:nodoc:
           end
 
           def nested_set_scope(options = {})
-            options = {:order => quoted_order_column_name}.merge(options)
+            options = {:order => quoted_order_column_full_name}.merge(options)
 
             order(options.delete(:order)).scoped options
           end


### PR DESCRIPTION
On 2-1-stable 3d5ac746542, Redmine test fails.
https://bitbucket.org/marutosi/redmine-bb-awesome_nested_set-use-gem/src/2ac1078370/Gemfile#cl-10
https://drone.io/bitbucket.org/marutosi/redmine-bb-awesome_nested_set-use-gem/2

<pre>
 13) Error:
    test_visible_and_nested_set_scopes(IssueTest):
    ActiveRecord::StatementInvalid: Mysql2::Error: Column 'lft' in order clause is ambiguous:
</pre>


http://www.redmine.org/projects/redmine/repository/revisions/12689/annotate/trunk/test/unit/issue_test.rb#L332

<pre>
  def test_visible_and_nested_set_scopes
    assert_equal 0, Issue.find(1).descendants.visible.all.size
  end
</pre>
