### PR TITLE
Fix for mssql with jruby/activerecord-jdbc-adapter

### DIFF
--- a/lib/awesome_nested_set/model/validatable.rb
+++ b/lib/awesome_nested_set/model/validatable.rb
@@ -17,7 +17,7 @@ module CollectiveIdea
           def no_duplicates_for_columns?
             [quoted_left_column_full_name, quoted_right_column_full_name].all? do |column|
               # No duplicates
-              select("#{scope_string}#{column}, COUNT(#{column})").
+              select("#{scope_string}#{column}, COUNT(#{column}) as _count").
                 group("#{scope_string}#{column}").
                 having("COUNT(#{column}) > 1").
                 first.nil?


### PR DESCRIPTION
Fixes an awesome_nested_set bug which occurs with mssql with jruby/activerecord-jdbc-adapter:
ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: No column was specified for column 3 of 't'.: SELECT t.\* FROM ( SELECT ROW_NUMBER() OVER(ORDER BY MIN(users.id)) AS _row_num, [users].[lft], COUNT([users].[lft]) FROM [users]  GROUP BY [users].[lft] HAVING COUNT([users].[lft]) > 1 ) AS t WHERE t._row_num BETWEEN 1 AND 1

Partially fixes jruby/activerecord-jdbc-adapter#437
