### PR TITLE
Fix #rebuild! (was rebuilding root nodes but not children)

### DIFF
--- a/lib/awesome_nested_set.rb
+++ b/lib/awesome_nested_set.rb
@@ -180,7 +180,7 @@ module CollectiveIdea #:nodoc:
             # set left
             node[left_column_name] = indices[scope.call(node)] += 1
             # find
-            find(:all, :conditions => ["#{quoted_parent_column_name} = ? #{scope.call(node)}", node], :order => "#{quoted_left_column_name}, #{quoted_right_column_name}, id").each{|n| set_left_and_rights.call(n) }
+            find(:all, :conditions => ["#{quoted_parent_column_name} = ? #{scope.call(node)}", node.send(self.primary_key)], :order => "#{quoted_left_column_name}, #{quoted_right_column_name}, id").each{|n| set_left_and_rights.call(n) }
             # set right
             node[right_column_name] = indices[scope.call(node)] += 1
             node.save!


### PR DESCRIPTION
It was only rebuilding lft/rgt for root nodes, not children. Caused by AR not substituting `node` for its primary key in the generated SQL. See below:

```
[2] pry(Department)> find(:all, :conditions => ["#{quoted_parent_column_name} = ? #{scope.call(node)}", node], :order => "#{quoted_left_column_name}, #{quoted_right_column_name}, id")
  Company Load (0.9ms)   SELECT "companies".* FROM "companies" WHERE ("companies"."id" = 43) 
  Department Load (0.6ms)   SELECT "departments".* FROM "departments" WHERE ("parent_id" = NULL AND "company_id" = 43 ) AND ("departments".company_id = 43) ORDER BY "lft", "rgt", id
=> []
[3] pry(Department)> node
=> #<Department id: 1802, created_at: "2013-04-11 22:03:08", updated_at: "2014-04-03 19:55:20", company_id: 43, parent_id: nil, lft: 1, rgt: 2, name: "Uncategorized", full_name: "Uncategorized">
```
