### PR TITLE
Improve deadlock detection, fix for Rails 4.1

### DIFF
--- a/lib/awesome_nested_set/model/transactable.rb
+++ b/lib/awesome_nested_set/model/transactable.rb
@@ -10,8 +10,8 @@ module CollectiveIdea #:nodoc:
             begin
               transaction(&block)
             rescue ActiveRecord::StatementInvalid => error
-              raise unless connection.open_transactions.zero?
-              raise unless error.message =~ /Deadlock found when trying to get lock|Lock wait timeout exceeded/
+              raise unless self.class.connection.open_transactions.zero?
+              raise unless error.message =~ /[Dd]eadlock|Lock wait timeout exceeded/
               raise unless retry_count < 10
               retry_count += 1
               logger.info "Deadlock detected on retry #{retry_count}, restarting transaction"


### PR DESCRIPTION
The broader regular expression should also retry
deadlocks in Postgres, SQL Server and possibly others too.
