### PR TITLE
Fixed docs for move_to_right_of

### DIFF
--- a/lib/awesome_nested_set/model/movable.rb
+++ b/lib/awesome_nested_set/model/movable.rb
@@ -29,7 +29,7 @@ module CollectiveIdea #:nodoc:
             move_to node, :left
           end
 
-          # Move the node to the left of another node
+          # Move the node to the right of another node
           def move_to_right_of(node)
             move_to node, :right
           end


### PR DESCRIPTION
It incorrectly stated move left of.
