### PR TITLE
refactor so shifting siblings left after a prune happens after the node is pruned.

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -55,7 +55,8 @@ module CollectiveIdea #:nodoc:
         acts_as_nested_set_relate_parent!
         acts_as_nested_set_relate_children!
 
-        attr_accessor :skip_before_destroy
+        attr_accessor :skip_destroy_descendants
+        attr_accessor :skip_update_siblings_for_remaining_nodes
 
         acts_as_nested_set_prevent_assignment_to_reserved_columns!
         acts_as_nested_set_define_callbacks!
@@ -68,6 +69,7 @@ module CollectiveIdea #:nodoc:
         before_save    :store_new_parent
         after_save     :move_to_new_parent, :set_depth!
         before_destroy :destroy_descendants
+        after_destroy  :update_siblings_for_remaining_nodes
 
         define_model_callbacks :move
       end

--- a/lib/awesome_nested_set/model/prunable.rb
+++ b/lib/awesome_nested_set/model/prunable.rb
@@ -16,6 +16,9 @@ module CollectiveIdea #:nodoc:
 
               return false unless destroy_or_delete_descendants
 
+              # Reload is needed because children may have updated their parent (self) during deletion.
+              reload
+
               # Don't allow multiple calls to destroy to corrupt the set
               self.skip_destroy_descendants = true
             end

--- a/lib/awesome_nested_set/move.rb
+++ b/lib/awesome_nested_set/move.rb
@@ -24,9 +24,13 @@ module CollectiveIdea #:nodoc:
 
           lock_nodes_between! a, d
 
-          nested_set_scope.where(where_statement(a, d)).update_all(
-            conditions(a, b, c, d)
-          )
+          # move nodes to the right starting with the right most nodes to avoid
+          # unique constraint violations
+          nested_set_scope.
+            unscope(:order).
+            order(instance_arel_table[:lft].desc).
+            where(where_statement(a, d)).
+            update_all(conditions(a, b, c, d))
         end
 
         private


### PR DESCRIPTION
This allows for a unique constraint on lft, rgt, scope_columns.

Adding this constraint helps to ensure the tree cannot be corrupted,
particularly by race conditions when inserting root nodes into a tree
concurrently.
