### PR TITLE
[2-1-stable] use custom excpetions in Transactable

### DIFF
--- a/lib/awesome_nested_set/model/transactable.rb
+++ b/lib/awesome_nested_set/model/transactable.rb
@@ -14,6 +14,8 @@ module CollectiveIdea #:nodoc:
             retry_count = 0
             begin
               transaction(&block)
+            rescue CollectiveIdea::Acts::NestedSet::Move::ImpossibleMove
+              raise
             rescue ActiveRecord::StatementInvalid => error
               raise OpenTransactionsIsNotZero.new(error.message) unless connection.open_transactions.zero?
               raise unless error.message =~ /Deadlock found when trying to get lock|Lock wait timeout exceeded/

--- a/lib/awesome_nested_set/move.rb
+++ b/lib/awesome_nested_set/move.rb
@@ -110,9 +110,12 @@ module CollectiveIdea #:nodoc:
           [bound, other_bound]
         end
 
+        class ImpossibleMove < ActiveRecord::StatementInvalid
+        end
+
         def prevent_impossible_move
           if !root && !instance.move_possible?(target)
-            raise ActiveRecord::ActiveRecordError, "Impossible move, target node cannot be inside moved tree."
+            raise ImpossibleMove, "Impossible move, target node cannot be inside moved tree."
           end
         end
 


### PR DESCRIPTION
Caller can rescue only NestedSet excptions.

For example in controller:

<pre>
rescue_from CollectiveIdea::Acts::NestedSet::Model::Transactable::OpenTransactionsIsNotZero,
            CollectiveIdea::Acts::NestedSet::Model::Transactable::DeadlockDetected,
            :with => :nestedset_locked
</pre>