### PR TITLE
[2-1-stable] remove "unless connection.open_transactions.zero?" condition

### DIFF
--- a/lib/awesome_nested_set/model/transactable.rb
+++ b/lib/awesome_nested_set/model/transactable.rb
@@ -10,7 +10,6 @@ module CollectiveIdea #:nodoc:
             begin
               transaction(&block)
             rescue ActiveRecord::StatementInvalid => error
-              raise unless connection.open_transactions.zero?
               raise unless error.message =~ /Deadlock found when trying to get lock|Lock wait timeout exceeded/
               raise unless retry_count < 10
               retry_count += 1


### PR DESCRIPTION
In nested transaction, if exception occurs, re-raise immediately.
It is not expected behavior.
