### PR TITLE
I found a bug with a model with default_scope and add a test

### DIFF
--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -148,6 +148,17 @@ module CollectiveIdea #:nodoc:
           self.class.base_class.nested_set_scope options
         end
 
+        # Separate an other `nested_set_scope` for unscoped model
+        # because normal query still need activerecord `default_scope`
+        # Only activerecord callbacks need unscoped model to handle the nested set records
+        # And class level `nested_set_scope` seems just for query `root` `child` .. etc
+        # I think we don't have to provide unscoped `nested_set_scope` in class level.
+        def nested_set_scope_without_default_scope(*args)
+          self.class.unscoped do
+            nested_set_scope(*args)
+          end
+        end
+
         def to_text
           self_and_descendants.map do |node|
             "#{'*'*(node.level+1)} #{node.primary_id} #{node.to_s} (#{node.parent_id}, #{node.left}, #{node.right})"

--- a/lib/awesome_nested_set/move.rb
+++ b/lib/awesome_nested_set/move.rb
@@ -24,7 +24,7 @@ module CollectiveIdea #:nodoc:
 
           lock_nodes_between! a, d
 
-          nested_set_scope.where(where_statement(a, d)).update_all(
+          nested_set_scope_without_default_scope.where(where_statement(a, d)).update_all(
             conditions(a, b, c, d)
           )
         end
@@ -33,7 +33,7 @@ module CollectiveIdea #:nodoc:
 
         delegate :left, :right, :left_column_name, :right_column_name,
                  :quoted_left_column_name, :quoted_right_column_name,
-                 :quoted_parent_column_name, :parent_column_name, :nested_set_scope,
+                 :quoted_parent_column_name, :parent_column_name, :nested_set_scope_without_default_scope,
                  :primary_column_name, :quoted_primary_column_name, :primary_id,
                  :to => :instance
 
@@ -121,7 +121,7 @@ module CollectiveIdea #:nodoc:
           when :child then right(target)
           when :left  then left(target)
           when :right then right(target) + 1
-          when :root  then nested_set_scope.pluck(right_column_name).max + 1
+          when :root  then nested_set_scope_without_default_scope.pluck(right_column_name).max + 1
           else raise ActiveRecord::ActiveRecordError, "Position should be :child, :left, :right or :root ('#{position}' received)."
           end
         end

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -1,8 +1,8 @@
-require 'spec_helper'
+# require 'spec_helper'
 
 describe "AwesomeNestedSet" do
   before(:all) do
-    self.class.fixtures :categories, :departments, :notes, :things, :brokens, :users
+    self.class.fixtures :categories, :departments, :notes, :things, :brokens, :users, :default_scoped_models
   end
 
   describe "defaults" do
@@ -1219,6 +1219,23 @@ describe "AwesomeNestedSet" do
         Category.acts_as_nested_set_options[:dependent] = :restrict_with_error
         leaf = Category.last
         assert_equal leaf, leaf.destroy
+      end
+    end
+    describe "model with default_scope" do
+      before(:all) do
+        self.class.fixtures :categories
+      end
+
+      it "should have correct #lft & #rgt" do
+        parent = DefaultScopedModel.find(6)
+        
+        DefaultScopedModel.send(:default_scope, Proc.new { parent.reload.self_and_descendants })
+
+        children = parent.children.create(name: 'Helloworld')
+            
+        DefaultScopedModel.unscoped do
+          expect(children.is_descendant_of?(parent.reload)).to be true
+        end
       end
     end
   end

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -1222,17 +1222,13 @@ describe "AwesomeNestedSet" do
       end
     end
     describe "model with default_scope" do
-      before(:all) do
-        self.class.fixtures :categories
-      end
-
       it "should have correct #lft & #rgt" do
         parent = DefaultScopedModel.find(6)
         
         DefaultScopedModel.send(:default_scope, Proc.new { parent.reload.self_and_descendants })
 
         children = parent.children.create(name: 'Helloworld')
-            
+
         DefaultScopedModel.unscoped do
           expect(children.is_descendant_of?(parent.reload)).to be true
         end

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -1,4 +1,4 @@
-# require 'spec_helper'
+require 'spec_helper'
 
 describe "AwesomeNestedSet" do
   before(:all) do

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -1,5 +1,13 @@
 ActiveRecord::Schema.define(:version => 0) do
 
+  create_table :default_scoped_models, :force => true do |t|
+    t.column :name, :string
+    t.column :parent_id, :integer
+    t.column :lft, :integer
+    t.column :rgt, :integer
+    t.column :depth, :integer
+  end
+
   create_table :categories, :force => true do |t|
     t.column :name, :string
     t.column :parent_id, :integer

--- a/spec/fixtures/default_scoped_models.yml
+++ b/spec/fixtures/default_scoped_models.yml
@@ -1,0 +1,39 @@
+top_level:
+  id: 1
+  name: Top Level
+  lft: 1
+  rgt: 10
+child_1:
+  id: 2
+  name: Child 1
+  parent_id: 1
+  lft: 2
+  rgt: 3
+child_2:
+  id: 3
+  name: Child 2
+  parent_id: 1
+  lft: 4
+  rgt: 7
+child_2_1:
+  id: 4
+  name: Child 2.1
+  parent_id: 3
+  lft: 5
+  rgt: 6
+child_3:
+  id: 5
+  name: Child 3
+  parent_id: 1
+  lft: 8
+  rgt: 9
+top_level_2:
+  id: 6
+  name: Top Level 2
+  lft: 11
+  rgt: 12
+top_level_3:
+  id: 7
+  name: Top Level 3
+  lft: 13
+  rgt: 14

--- a/spec/fixtures/default_scoped_models.yml
+++ b/spec/fixtures/default_scoped_models.yml
@@ -2,38 +2,20 @@ top_level:
   id: 1
   name: Top Level
   lft: 1
-  rgt: 10
+  rgt: 4
 child_1:
   id: 2
   name: Child 1
   parent_id: 1
   lft: 2
   rgt: 3
-child_2:
-  id: 3
-  name: Child 2
-  parent_id: 1
-  lft: 4
-  rgt: 7
-child_2_1:
-  id: 4
-  name: Child 2.1
-  parent_id: 3
-  lft: 5
-  rgt: 6
-child_3:
-  id: 5
-  name: Child 3
-  parent_id: 1
-  lft: 8
-  rgt: 9
 top_level_2:
   id: 6
   name: Top Level 2
-  lft: 11
-  rgt: 12
+  lft: 5
+  rgt: 6
 top_level_3:
   id: 7
   name: Top Level 3
-  lft: 13
-  rgt: 14
+  lft: 7
+  rgt: 8

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -4,6 +4,10 @@ class Note < ActiveRecord::Base
   belongs_to :user, inverse_of: :notes
 end
 
+class DefaultScopedModel < ActiveRecord::Base
+  acts_as_nested_set
+end
+
 class Default < ActiveRecord::Base
   self.table_name = 'categories'
   acts_as_nested_set


### PR DESCRIPTION
My project use `default_scope` for multi-tenancy and my `User` model is nested, associate with self. 

```ruby
class User < ActiveRecord::Base
  default_scope { Registry.current_user.self_and_descendants if Registry.current_user.present? }
end
```

The problem is: 

When i create a user with default_scope, awesome_nested_set will calculate wrong `#lft` & `#rgt`, and it will make `parent.descendant` cannot found, i fixed it already, but i don't know if my changed effect other things.

please check this pull request. thanks.