### PR TITLE
Updated database create documentation to reflect what awesome_nested_set expects

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ class CreateCategories < ActiveRecord::Migration
       t.integer :rgt, :null => false, :index => true
       
       # optional fields
-      t.integer :depth, :null => false, :default => 0
-      t.integer :children_count, :null => false, :default => 0
+      t.integer :depth, :null => false
+      t.integer :children_count, :null => false
     end
   end
 


### PR DESCRIPTION
Awesome Gem! I hope I can contribute more to this as I become more familiar with it!

In the name of having a proper database architecture, the database creation of columns should include default values, and not null if applicable. 

I bring this up because I was moving from a previous setup with a standard parent_id > id relationship to awesome_nested_set. Although instead of parent_id being nil, it was set to '0' to denote a root node.  

Granted, in hind sight, looking at the documentation, the lack of any column defaults should have given this away to me but alas, here I am a few hours later. :)
