### PR TITLE
Ensure that nested_set queries respect model's default_scope

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Ensure that nested_set queries respect the model's default_scope. [oesgalha](https://github.com/oesgalha)
+
 3.0.2
 * Fix `dependent: :restrict_with_exception` not allowing a delete to occur. [Brendan Kilfoil]
 * Replace `Arel::SelectManager#join_sql` with `Arel::SelectManager#join_sources` as `Arel::Node#joins` accepts AST as well. [Swanand Pagnis]

--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -145,7 +145,7 @@ module CollectiveIdea #:nodoc:
             end
           end
 
-          self.class.base_class.unscoped.nested_set_scope options
+          self.class.base_class.nested_set_scope options
         end
 
         # Separate an other `nested_set_scope` for unscoped model
@@ -154,7 +154,7 @@ module CollectiveIdea #:nodoc:
         # And class level `nested_set_scope` seems just for query `root` `child` .. etc
         # I think we don't have to provide unscoped `nested_set_scope` in class level.
         def nested_set_scope_without_default_scope(*args)
-          self.class.unscoped do
+          self.class.base_class.unscoped do
             nested_set_scope(*args)
           end
         end
@@ -182,7 +182,7 @@ module CollectiveIdea #:nodoc:
         end
 
         def right_most_node
-          @right_most_node ||= nested_set_scope(
+          @right_most_node ||= nested_set_scope_without_default_scope(
             :order => "#{quoted_right_column_full_name} desc"
           ).first
         end

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -1233,6 +1233,7 @@ describe "AwesomeNestedSet" do
       it "should have correct #lft & #rgt" do
         parent = DefaultScopedModel.find(6)
 
+        DefaultScopedModel.send(:default_scopes=, [])
         DefaultScopedModel.send(:default_scope, Proc.new { parent.reload.self_and_descendants })
 
         children = parent.children.create(name: 'Helloworld')
@@ -1240,6 +1241,21 @@ describe "AwesomeNestedSet" do
         DefaultScopedModel.unscoped do
           expect(children.is_descendant_of?(parent.reload)).to be true
         end
+      end
+
+      it "should respect the default_scope" do
+        DefaultScopedModel.send(:default_scopes=, [])
+        DefaultScopedModel.send(:default_scope, -> { DefaultScopedModel.where(draft: false) })
+
+        no_parents = DefaultScopedModel.find(1)
+
+        expect(no_parents.self_and_ancestors.count).to eq(1)
+
+        no_parents.draft = true
+        no_parents.save
+
+        other_root = DefaultScopedModel.create!(name: 'Another root')
+        expect(other_root.self_and_ancestors.count).to eq(1)
       end
     end
   end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.column :lft, :integer
     t.column :rgt, :integer
     t.column :depth, :integer
+    t.column :draft, :boolean, default: false
   end
 
   create_table :categories, :force => true do |t|

--- a/spec/fixtures/default_scoped_models.yml
+++ b/spec/fixtures/default_scoped_models.yml
@@ -3,19 +3,29 @@ top_level:
   name: Top Level
   lft: 1
   rgt: 4
+  draft: false
 child_1:
   id: 2
   name: Child 1
   parent_id: 1
   lft: 2
   rgt: 3
+  draft: false
 top_level_2:
   id: 6
   name: Top Level 2
   lft: 5
   rgt: 6
+  draft: false
 top_level_3:
   id: 7
   name: Top Level 3
   lft: 7
   rgt: 8
+  draft: false
+old_root:
+  id: 8
+  name: Top Level
+  lft: 1
+  rgt: 4
+  draft: true


### PR DESCRIPTION
Hello,

Some methods added by acts_as_nested_set were not respecting my default scopes.
I added a exemple spec case and a fix proposal.

In the example, the default_scope of the model is:
```ruby
DefaultScopedModel.where(draft: false)
````
Before this patch a certain model without parents could return more than one record to `self_and_ancestors` because of the `rgt` and `lft` values, even if some of those models were marked as a draft (draft == true). The query generated by `self_and_ancestors` would not use the `where(draft: false)` clause from the default_scope.

Now it does.

Thanks
