### PR TITLE
FIx for ambiguous order for children

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -87,7 +87,7 @@ module CollectiveIdea #:nodoc:
           ) if acts_as_nested_set_options[ar_callback]
         end
 
-        has_many :children, -> { order(quoted_order_column_name) },
+        has_many :children, -> { order(quoted_order_column_full_name) },
                  has_many_children_options
       end
 


### PR DESCRIPTION
FIx for when children are used in a join statement with another awesome nested set model causing an ambigous order.

resolves #182 