### PR TITLE
Create "nullify" option for the :dependent functionality

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+3.0.3
+* Add :nullify option to :dependent functionality to orphan children rather
+than destroy them.
+
 3.0.2
 * Fix `dependent: :restrict_with_exception` not allowing a delete to occur. [Brendan Kilfoil]
 * Replace `Arel::SelectManager#join_sql` with `Arel::SelectManager#join_sources` as `Arel::Node#joins` accepts AST as well. [Swanand Pagnis]

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can pass various options to `acts_as_nested_set` macro. Configuration option
 * `right_column`: column name for right boundary data (default: rgt)
 * `depth_column`: column name for the depth data default (default: depth)
 * `scope`: restricts what is to be considered a list. Given a symbol, it'll attach “_id” (if it hasn't been already) and use that as the foreign key restriction. You can also pass an array to scope by multiple attributes. Example: `acts_as_nested_set :scope => [:notable_id, :notable_type]`
-* `dependent`: behavior for cascading destroy. If set to :destroy, all the child objects are destroyed alongside this object by calling their destroy method. If set to :delete_all (default), all the child objects are deleted without calling their destroy method.
+* `dependent`: behavior for cascading destroy. If set to :destroy, all the child objects are destroyed alongside this object by calling their destroy method. If set to :delete_all (default), all the child objects are deleted without calling their destroy method. If set to :nullify, all child objects will become orphaned and become roots themselves.
 * `counter_cache`: adds a counter cache for the number of children. defaults to false. Example: `acts_as_nested_set :counter_cache => :children_count`
 * `order_column`: on which column to do sorting, by default it is the left_column_name. Example: `acts_as_nested_set :order_column => :position`
 

--- a/lib/awesome_nested_set/model/prunable.rb
+++ b/lib/awesome_nested_set/model/prunable.rb
@@ -51,7 +51,9 @@ module CollectiveIdea #:nodoc:
                 return false
               end
               return true
-            else
+             elsif acts_as_nested_set_options[:dependent] == :nullify
+               descendants.update_all(parent_id: nil)
+             else
               descendants.delete_all
             end
           end

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -1201,6 +1201,15 @@ describe "AwesomeNestedSet" do
       expect(Category.where(parent_id: root.id)).to be_empty
     end
 
+    it 'nullify should nullify child parent IDs rather than deleting' do
+      Category.acts_as_nested_set_options[:dependent] = :nullify
+      root = Category.root
+      child_ids = root.child_ids
+      root.destroy!
+      expect(Category.where(id: child_ids)).to_not be_empty
+      expect(Category.where(parent_id: root.id)).to be_empty
+    end
+
     describe 'restrict_with_exception' do
       it 'raises an exception' do
         Category.acts_as_nested_set_options[:dependent] = :restrict_with_exception


### PR DESCRIPTION
We came across a use case for this today, whereby instead of actually destroying all descendants of a node when you destroy it we actually wanted them to become new root nodes. What we ended up doing was overriding the destroy_or_delete_descendents method in that model and nullifying there, I was hoping though that we could maybe get that functionality incorporated into the master?

using the :dependant option seemed like the most natural place for this to live because it mirrors rails' functionality (when specifying associations you can state :nullify as the strategy).