### PR TITLE
update counter cache when moving

### DIFF
--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -174,6 +174,7 @@ module CollectiveIdea #:nodoc:
 
         def store_new_parent
           @move_to_new_parent_id = send("#{parent_column_name}_changed?") ? parent_id : false
+          @in_saving_callback = true
           true # force callback to return true
         end
 

--- a/lib/awesome_nested_set/model/movable.rb
+++ b/lib/awesome_nested_set/model/movable.rb
@@ -105,8 +105,20 @@ module CollectiveIdea #:nodoc:
                 self.reload_nested_set
 
                 Move.new(target, position, self).move
+
+                update_counter_cache(target, position, self) if self.acts_as_nested_set_options[:counter_cache] && !@in_saving_callback
               end
               after_move_to(target, position)
+            end
+          end
+
+          def update_counter_cache target, position, instance
+            self.class.decrement_counter self.acts_as_nested_set_options[:counter_cache], instance.parent.id if instance.parent
+            case position
+            when :child
+              self.class.increment_counter self.acts_as_nested_set_options[:counter_cache], target.id
+            when :left, :right
+              self.class.increment_counter self.acts_as_nested_set_options[:counter_cache], target.parent.id if target.parent
             end
           end
 

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -1050,6 +1050,74 @@ describe "AwesomeNestedSet" do
       note1.reload
       expect(note1[:children_count]).to eq(1)
     end
+
+    it 'decrements counter cache of previous parent when moving to root' do
+      prev_parent = things(:parent1)
+      note1 = things(:child_2)
+      expect {
+        note1.move_to_root
+        prev_parent.reload
+      }.to change { prev_parent.children_count }.by -1
+    end
+
+    it 'decrements counter cache of previous parent when moving to child of other' do
+      prev_parent = things(:parent1)
+      note1 = things(:child_1)
+      target = things(:child_2)
+      expect {
+        note1.move_to_child_of(target)
+        prev_parent.reload
+      }.to change { prev_parent.children_count }.by -1
+    end
+
+    it 'increments counter cache of current parent when moving to child of other' do
+      note1 = things(:child_1)
+      target = things(:child_2)
+      expect {
+        note1.move_to_child_of(target)
+        target.reload
+      }.to change { target.children_count }.by 1
+    end
+
+    it 'decrements counter cache of previous parent when moving to left of other' do
+      prev_parent = things(:parent1)
+      note1 = things(:child_1)
+      target = things(:child_2_1)
+      expect {
+        note1.move_to_left_of(target)
+        prev_parent.reload
+      }.to change { prev_parent.children_count }.by -1
+    end
+
+    it 'increments counter cache of current parent when moving to left of other' do
+      note1 = things(:child_1)
+      parent_target = things(:child_2)
+      target = things(:child_2_1)
+      expect {
+        note1.move_to_left_of(target)
+        parent_target.reload
+      }.to change { parent_target.children_count }.by 1
+    end
+
+    it 'decrements counter cache of previous parent when moving to right of other' do
+      prev_parent = things(:parent1)
+      note1 = things(:child_1)
+      target = things(:child_2_1)
+      expect {
+        note1.move_to_right_of(target)
+        prev_parent.reload
+      }.to change { prev_parent.children_count }.by -1
+    end
+
+    it 'increments counter cache of current parent when moving to right of other' do
+      note1 = things(:child_1)
+      parent_target = things(:child_2)
+      target = things(:child_2_1)
+      expect {
+        note1.move_to_right_of(target)
+        parent_target.reload
+      }.to change { parent_target.children_count }.by 1
+    end
   end
 
   describe "association callbacks on children" do

--- a/spec/fixtures/things.yml
+++ b/spec/fixtures/things.yml
@@ -1,3 +1,10 @@
+
+#   parent1
+#  /      \
+#child_1  child_2
+#          /
+#        child_2_1
+
 parent1:
   id: 1
   body: Top Level
@@ -17,7 +24,7 @@ child_2:
   parent_id: 1
   lft: 4
   rgt: 7
-  children_count: 0
+  children_count: 1
 child_2_1:
   id: 4
   body: Child 2.1


### PR DESCRIPTION
Can't update counter_cache if use the method like 'move_to_*' .
I add the code that sets counter_cache when using these methods.
It may be useful for others. The code may be ugly, please forgive.