### PR TITLE
Use the current models connection when generating quoted column names

### DIFF
--- a/lib/awesome_nested_set/columns.rb
+++ b/lib/awesome_nested_set/columns.rb
@@ -32,23 +32,23 @@ module CollectiveIdea #:nodoc:
         end
 
         def quoted_left_column_name
-          ActiveRecord::Base.connection.quote_column_name(left_column_name)
+          model_connection.quote_column_name(left_column_name)
         end
 
         def quoted_right_column_name
-          ActiveRecord::Base.connection.quote_column_name(right_column_name)
+          model_connection.quote_column_name(right_column_name)
         end
 
         def quoted_depth_column_name
-          ActiveRecord::Base.connection.quote_column_name(depth_column_name)
+          model_connection.quote_column_name(depth_column_name)
         end
 
         def quoted_primary_column_name
-          ActiveRecord::Base.connection.quote_column_name(primary_column_name)
+          model_connection.quote_column_name(primary_column_name)
         end
 
         def quoted_parent_column_name
-          ActiveRecord::Base.connection.quote_column_name(parent_column_name)
+          model_connection.quote_column_name(parent_column_name)
         end
 
         def quoted_scope_column_names
@@ -56,7 +56,7 @@ module CollectiveIdea #:nodoc:
         end
 
         def quoted_order_column_name
-          ActiveRecord::Base.connection.quote_column_name(order_column)
+          model_connection.quote_column_name(order_column)
         end
 
         def quoted_primary_key_column_full_name
@@ -77,6 +77,10 @@ module CollectiveIdea #:nodoc:
 
         def quoted_parent_column_full_name
           "#{quoted_table_name}.#{quoted_parent_column_name}"
+        end
+
+        def model_connection
+          self.is_a?(Class) ? self.connection : self.class.connection
         end
       end
     end


### PR DESCRIPTION
If the environment has more than one connection, there was a chance that column names would get the wrong quoting