### PR TITLE
Fix counter cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ gem 'awesome_nested_set'
 To make use of `awesome_nested_set` your model needs to have 3 fields:
 `lft`, `rgt`, and `parent_id`. The names of these fields are configurable.
 You can also have optional fields: `depth` and `children_count`. These fields are configurable.
+Note that the `childrent_count` column must have `null: false` and `default: 0` to
+function properly.
 
 ```ruby
 class CreateCategories < ActiveRecord::Migration
@@ -66,7 +68,7 @@ You can pass various options to `acts_as_nested_set` macro. Configuration option
 * `left_column`: column name for left boundary data (default: lft)
 * `right_column`: column name for right boundary data (default: rgt)
 * `depth_column`: column name for the depth data default (default: depth)
-* `scope`: restricts what is to be considered a list. Given a symbol, it'll attach “_id” (if it hasn't been already) and use that as the foreign key restriction. You can also pass an array to scope by multiple attributes. Example: `acts_as_nested_set :scope => [:notable_id, :notable_type]`
+* `scope`: restricts what is to be considered a list. Given a symbol, it'll attach `_id` (if it hasn't been already) and use that as the foreign key restriction. You can also pass an array to scope by multiple attributes. Example: `acts_as_nested_set :scope => [:notable_id, :notable_type]`
 * `dependent`: behavior for cascading destroy. If set to :destroy, all the child objects are destroyed alongside this object by calling their destroy method. If set to :delete_all (default), all the child objects are deleted without calling their destroy method. If set to :nullify, all child objects will become orphaned and become roots themselves.
 * `counter_cache`: adds a counter cache for the number of children. defaults to false. Example: `acts_as_nested_set :counter_cache => :children_count`
 * `order_column`: on which column to do sorting, by default it is the left_column_name. Example: `acts_as_nested_set :order_column => :position`

--- a/lib/awesome_nested_set/columns.rb
+++ b/lib/awesome_nested_set/columns.rb
@@ -31,6 +31,10 @@ module CollectiveIdea #:nodoc:
           Array(acts_as_nested_set_options[:scope])
         end
 
+        def counter_cache_column_name
+          acts_as_nested_set_options[:counter_cache]
+        end
+
         def quoted_left_column_name
           ActiveRecord::Base.connection.quote_column_name(left_column_name)
         end

--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -232,6 +232,20 @@ module CollectiveIdea #:nodoc:
           end
         end
 
+        def update_counter_cache
+          return unless acts_as_nested_set_options[:counter_cache]
+
+          # Decrease the counter for all old parents
+          if old_parent = self.parent
+            self.class.decrement_counter(acts_as_nested_set_options[:counter_cache], old_parent)
+          end
+
+          # Increase the counter for all new parents
+          if new_parent = self.reload.parent
+            self.class.increment_counter(acts_as_nested_set_options[:counter_cache], new_parent)
+          end
+        end
+
         def set_default_left_and_right
           # adds the new node to the right of all existing nodes
           self[left_column_name] = right_most_bound + 1

--- a/lib/awesome_nested_set/model/movable.rb
+++ b/lib/awesome_nested_set/model/movable.rb
@@ -105,6 +105,7 @@ module CollectiveIdea #:nodoc:
                 self.reload_nested_set
 
                 Move.new(target, position, self).move
+                update_counter_cache
               end
               after_move_to(target, position)
             end

--- a/lib/awesome_nested_set/tree.rb
+++ b/lib/awesome_nested_set/tree.rb
@@ -6,7 +6,7 @@ module CollectiveIdea #:nodoc:
         attr_accessor :indices
 
         delegate :left_column_name, :right_column_name, :quoted_parent_column_full_name,
-                 :order_for_rebuild, :scope_for_rebuild,
+                 :order_for_rebuild, :scope_for_rebuild, :counter_cache_column_name,
                  :to => :model
 
         def initialize(model, validate_nodes)
@@ -23,6 +23,7 @@ module CollectiveIdea #:nodoc:
             # setup index for this scope
             indices[scope_for_rebuild.call(root_node)] ||= 0
             set_left_and_rights(root_node)
+            reset_counter_cache(root_node)
           end
         end
 
@@ -56,6 +57,15 @@ module CollectiveIdea #:nodoc:
 
         def set_right!(node)
           node[right_column_name] = increment_indice!(node)
+        end
+
+        def reset_counter_cache(node)
+          return unless counter_cache_column_name
+          node.class.reset_counters(node.id, :children)
+
+          node.children.each do |child|
+            reset_counter_cache(child)
+          end
         end
       end
     end

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -731,6 +731,27 @@ describe "AwesomeNestedSet" do
     expect(before_text).to eq(Category.root.to_text)
   end
 
+  describe ".rebuild!" do
+    subject { Thing.rebuild! }
+    before { Thing.update_all(children_count: 0) }
+
+    context "when items have children" do
+      it "updates their counter_cache" do
+        expect { subject }.to change {
+          things(:parent1).reload.children_count }.to(2).from(0).
+          and change { things(:child_2).reload.children_count }.to(1).from(0)
+      end
+    end
+
+    context "when items do not have children" do
+      it "doesn't change their counter_cache" do
+        subject
+        expect(things(:child_1).reload.children_count).to eq(0)
+        expect(things(:child_2_1).reload.children_count).to eq(0)
+      end
+    end
+  end
+
   it "move_possible_for_sibling" do
     expect(categories(:child_2).move_possible?(categories(:child_1))).to be_truthy
   end

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -1025,30 +1025,22 @@ describe "AwesomeNestedSet" do
   end
 
   describe "counter_cache" do
+    let(:parent1) { things(:parent1) }
 
     it "should allow use of a counter cache for children" do
-      note1 = things(:parent1)
-      expect(note1.children.count).to eq(2)
+      expect(parent1.children_count).to eq(parent1.children.count)
     end
 
     it "should increment the counter cache on create" do
-      note1 = things(:parent1)
-      expect(note1.children.count).to eq(2)
-      expect(note1[:children_count]).to eq(2)
-      note1.children.create :body => 'Child 3'
-      expect(note1.children.count).to eq(3)
-      note1.reload
-      expect(note1[:children_count]).to eq(3)
+      expect {
+        parent1.children.create body: "Child 3"
+      }.to change { parent1.reload.children_count }.by(1)
     end
 
     it "should decrement the counter cache on destroy" do
-      note1 = things(:parent1)
-      expect(note1.children.count).to eq(2)
-      expect(note1[:children_count]).to eq(2)
-      note1.children.last.destroy
-      expect(note1.children.count).to eq(1)
-      note1.reload
-      expect(note1[:children_count]).to eq(1)
+      expect {
+        parent1.children.last.destroy
+      }.to change { parent1.reload.children_count }.by(-1)
     end
   end
 

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.column :lft, :integer
     t.column :rgt, :integer
     t.column :depth, :integer
-    t.column :children_count, :integer
+    t.column :children_count, :integer, null: false, default: 0
   end
 
   create_table :brokens, :force => true do |t|

--- a/spec/fixtures/things.yml
+++ b/spec/fixtures/things.yml
@@ -17,7 +17,7 @@ child_2:
   parent_id: 1
   lft: 4
   rgt: 7
-  children_count: 0
+  children_count: 1
 child_2_1:
   id: 4
   body: Child 2.1


### PR DESCRIPTION
My best attempt at fixing https://github.com/collectiveidea/awesome_nested_set/issues/295 and https://github.com/collectiveidea/awesome_nested_set/issues/294

If the `counter_cache` does not get updated when objects are moved around then it loses its usefulness very quickly. This PR does two important things:

1. Updates the `counter_cache` after any move.
2. Updates the `counter_cache` of all items in a `rebuild!`

All newly added code also comes with tests. This is a slightly more robust version of https://github.com/collectiveidea/awesome_nested_set/pull/319