### PR TITLE
Fix .all_roots_valid? method when model is ordered by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.0.5
+* Fix .all_roots_valid? method when model is ordered by default
+
 3.0.4
 * Reuse the current model's connection when available [Tim Bugai] [#322](https://github.com/collectiveidea/awesome_nested_set/pull/322)
 

--- a/lib/awesome_nested_set/model/validatable.rb
+++ b/lib/awesome_nested_set/model/validatable.rb
@@ -41,8 +41,10 @@ module CollectiveIdea
           end
 
           def each_root_valid?(roots_to_validate)
+            left_column = acts_as_nested_set_options[:left_column]
+            reordered_roots = roots_reordered_by_column(roots_to_validate, left_column)
             left = right = 0
-            roots_to_validate.all? do |root|
+            reordered_roots.all? do |root|
               (root.left > left && root.right > right).tap do
                 left = root.left
                 right = root.right
@@ -57,12 +59,21 @@ module CollectiveIdea
             }
           end
 
+          def roots_reordered_by_column(roots_to_reorder, column)
+            if roots_to_reorder.respond_to?(:reorder) # ActiveRecord's relation
+              roots_to_reorder.reorder(column)
+            elsif roots_to_reorder.respond_to?(:sort) # Array
+              roots_to_reorder.sort { |a, b| a.send(column) <=> b.send(column) }
+            else
+              roots_to_reorder
+            end
+          end
+
           def scope_string
             Array(acts_as_nested_set_options[:scope]).map do |c|
               connection.quote_column_name(c)
             end.push(nil).join(", ")
           end
-
         end
       end
     end

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -1238,6 +1238,7 @@ describe "AwesomeNestedSet" do
         expect(leaf.destroy).to eq(leaf)
       end
     end
+
     describe "model with default_scope" do
       it "should have correct #lft & #rgt" do
         parent = DefaultScopedModel.find(6)
@@ -1249,6 +1250,19 @@ describe "AwesomeNestedSet" do
         DefaultScopedModel.unscoped do
           expect(children.is_descendant_of?(parent.reload)).to be true
         end
+      end
+
+      it "is .all_roots_valid? even when default_scope has custom order" do
+        class DefaultScopedModel; default_scope -> { order(rgt: :desc) }; end
+        expect(DefaultScopedModel.all_roots_valid?).to be_truthy
+      end
+
+      it "is .all_roots_valid? even when uses multi scope" do
+        class DefaultScopedModel
+          acts_as_nested_set :scope => [:id]
+          default_scope -> { order(rgt: :desc) }
+        end
+        expect(DefaultScopedModel.all_roots_valid?).to be_truthy
       end
     end
   end


### PR DESCRIPTION
* Internals of #all_roots_valid? method assume that roots that come in argument are ordered by left column's field
* It's not true, when model has default order - in this case method returns false negative