### PR TITLE
don't use default scope when reloading target due to AR#where scoping

### DIFF
--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -264,7 +264,7 @@ module CollectiveIdea #:nodoc:
           if target.is_a? self.class.base_class
             target.reload
           elsif position != :root
-            nested_set_scope.where(primary_column_name => target).first!
+            nested_set_scope_without_default_scope.where(primary_column_name => target).first!
           end
         end
       end

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -719,6 +719,16 @@ describe "User", :type => :model do
     expect(User.valid?).to be_truthy
   end
 
+  it 'creates user when clause where provided' do
+    parent = User.first
+
+    expect do
+      User.where(name: "Chris-#{Time.current.to_f}").first_or_create! do |user|
+        user.parent = parent
+      end
+    end.to change { User.count }.by 1
+  end
+
   def check_structure(entries, structure)
     structure = structure.dup
     User.each_with_level(entries) do |user, level|


### PR DESCRIPTION
`User.where(name: "Chris")` is adding scope `name: "Chris"` so we can't find parent in `#reload_parent`