### PR TITLE
Fix version in CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-3.1.0
+3.1.1
 * Fix a reloading bug when using default scope [Krzysztof Rybka](https://github.com/krzysiek1507)
 
 3.1.0


### PR DESCRIPTION
This version should be a `3.1.1`, not a `3.1.0`.
This is introduced in 2e67e9a14.