### PR TITLE
Use ActiveSupport.on_load to inject modules

### DIFF
--- a/lib/awesome_nested_set.rb
+++ b/lib/awesome_nested_set.rb
@@ -1,8 +1,11 @@
+require 'active_support/lazy_load_hooks'
 require 'awesome_nested_set/awesome_nested_set'
-require 'active_record'
-ActiveRecord::Base.send :extend, CollectiveIdea::Acts::NestedSet
 
-if defined?(ActionView)
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.send :extend, CollectiveIdea::Acts::NestedSet
+end
+
+ActiveSupport.on_load(:action_view) do
   require 'awesome_nested_set/helper'
   ActionView::Base.send :include, CollectiveIdea::Acts::NestedSet::Helper
 end


### PR DESCRIPTION
This solves a load order issue where routes were not loaded in tests due to ActionView being referenced here before it was fully loaded.

The [rails documentation](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/lazy_load_hooks.rb#L2) seems to recommends using these hooks, so I have changed the injection into `ActiveRecord::Base` to use it as well instead of requiring active_record.

See also https://github.com/rails/rails-controller-testing/issues/24 especially [this comment](https://github.com/rails/rails-controller-testing/issues/24#issuecomment-231738446) for additional details.