### PR TITLE
lock combustion < 0.5.5

### DIFF
--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec-rails', '3.5.0.beta3'
   s.add_development_dependency 'rake', '~> 10'
-  s.add_development_dependency 'combustion', '>= 0.5.2'
+  s.add_development_dependency 'combustion', '>= 0.5.2', '< 0.5.5'
   s.add_development_dependency 'database_cleaner'
 end


### PR DESCRIPTION
`combustion` 0.5.5 is broken, has changed API and fails test setup