### PR TITLE
Make belongs_to relation optional again due to Rails 5 changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.1.2
+* Make belongs_to relation optional again [Jan Matusz](https://marahin.pl/)
+
 3.1.1
 * Fix a reloading bug when using default scope [Krzysztof Rybka](https://github.com/krzysiek1507)
 

--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -92,14 +92,17 @@ module CollectiveIdea #:nodoc:
       end
 
       def acts_as_nested_set_relate_parent!
-        belongs_to :parent, :class_name => self.base_class.to_s,
-                            :foreign_key => parent_column_name,
-                            :primary_key => primary_column_name,
-                            :counter_cache => acts_as_nested_set_options[:counter_cache],
-                            :inverse_of => (:children unless acts_as_nested_set_options[:polymorphic]),
-                            :polymorphic => acts_as_nested_set_options[:polymorphic],
-                            :touch => acts_as_nested_set_options[:touch],
-                            :optional => true
+        options = {
+          :class_name => self.base_class.to_s,
+          :foreign_key => parent_column_name,
+          :primary_key => primary_column_name,
+          :counter_cache => acts_as_nested_set_options[:counter_cache],
+          :inverse_of => (:children unless acts_as_nested_set_options[:polymorphic]),
+          :polymorphic => acts_as_nested_set_options[:polymorphic],
+          :touch => acts_as_nested_set_options[:touch]
+        }
+        options[:optional] = true if Rails::VERSION::MAJOR >= 5
+        belongs_to :parent, options
       end
 
       def acts_as_nested_set_default_options

--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -98,7 +98,8 @@ module CollectiveIdea #:nodoc:
                             :counter_cache => acts_as_nested_set_options[:counter_cache],
                             :inverse_of => (:children unless acts_as_nested_set_options[:polymorphic]),
                             :polymorphic => acts_as_nested_set_options[:polymorphic],
-                            :touch => acts_as_nested_set_options[:touch]
+                            :touch => acts_as_nested_set_options[:touch],
+                            :optional => true
       end
 
       def acts_as_nested_set_default_options

--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -101,7 +101,7 @@ module CollectiveIdea #:nodoc:
           :polymorphic => acts_as_nested_set_options[:polymorphic],
           :touch => acts_as_nested_set_options[:touch]
         }
-        options[:optional] = true if Rails::VERSION::MAJOR >= 5
+        options[:optional] = true if ActiveRecord::VERSION::MAJOR >= 5
         belongs_to :parent, options
       end
 

--- a/lib/awesome_nested_set/version.rb
+++ b/lib/awesome_nested_set/version.rb
@@ -1,3 +1,3 @@
 module AwesomeNestedSet
-  VERSION = '3.1.1' unless defined?(::AwesomeNestedSet::VERSION)
+  VERSION = '3.1.2' unless defined?(::AwesomeNestedSet::VERSION)
 end


### PR DESCRIPTION
Rails 5 changes brought a [new default setting for relations](http://blog.bigbinary.com/2016/02/15/rails-5-makes-belong-to-association-required-by-default.html) that breaks this Gem. 

Following the example shown in README / Wiki's cheatsheet, there is a `ActiveRecord::RecordInvalid: Validation failed: Parent must exist` validation error thrown.

Logically, assuming we are creating a rootnode there cannot be a Parent, as the record we are creating is going to be a parent itself. 

Changes introduced make the relation optional again as it was before Rails 5 introduction. 
