### PR TITLE
implemented :skip_destroy_descandants as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You can pass various options to `acts_as_nested_set` macro. Configuration option
 * `depth_column`: column name for the depth data default (default: depth)
 * `scope`: restricts what is to be considered a list. Given a symbol, it'll attach `_id` (if it hasn't been already) and use that as the foreign key restriction. You can also pass an array to scope by multiple attributes. Example: `acts_as_nested_set :scope => [:notable_id, :notable_type]`
 * `dependent`: behavior for cascading destroy. If set to :destroy, all the child objects are destroyed alongside this object by calling their destroy method. If set to :delete_all (default), all the child objects are deleted without calling their destroy method. If set to :nullify, all child objects will become orphaned and become roots themselves.
+* `skip_destroy_descandants`: If set to `true`, then it will skip any `dependent` callbacks.
 * `counter_cache`: adds a counter cache for the number of children. defaults to false. Example: `acts_as_nested_set :counter_cache => :children_count`
 * `order_column`: on which column to do sorting, by default it is the left_column_name. Example: `acts_as_nested_set :order_column => :position`
 * `touch`: If set to `true`, then the updated_at timestamp on the ancestors will be set to the current time whenever this object is saved or destroyed (default: false)

--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 5.1'
-
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'

--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -67,7 +67,7 @@ module CollectiveIdea #:nodoc:
         before_create  :set_default_left_and_right
         before_save    :store_new_parent
         after_save     :move_to_new_parent, :set_depth!
-        before_destroy :destroy_descendants
+        before_destroy :destroy_descendants unless acts_as_nested_set_options[:skip_destroy_descandants]
 
         define_model_callbacks :move
       end


### PR DESCRIPTION
if set to true, it will will completely skip any behavior to trash the children tree. useful if we just want to flag the root as temporary deleted (soft_delete) where we actually use the destroy method. othweise the root-entry will be flagged as a soft-deleted but the tree will be destroyed


