### PR TITLE
Remove Rails 5.2 warnings

### DIFF
--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -79,7 +79,7 @@ module CollectiveIdea #:nodoc:
           end
 
           def nested_set_scope(options = {})
-            options = {:order => quoted_order_column_full_name}.merge(options)
+            options = {:order => order_column}.merge(options)
 
             where(options[:conditions]).order(options.delete(:order))
           end
@@ -183,7 +183,7 @@ module CollectiveIdea #:nodoc:
 
         def right_most_node
           @right_most_node ||= nested_set_scope_without_default_scope(
-            :order => "#{quoted_right_column_full_name} desc"
+            :order => {right_column_name => :desc}
           ).first
         end
 


### PR DESCRIPTION
In my project, This is small patch remove all warnings.