### PR TITLE
Fix deprecation warnings on Rails 5.2

### DIFF
--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 5.2'
+  s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 5.3'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'pry'

--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -87,7 +87,7 @@ module CollectiveIdea #:nodoc:
           ) if acts_as_nested_set_options[ar_callback]
         end
 
-        has_many :children, -> { order(quoted_order_column_full_name) },
+        has_many :children, -> { order(order_column => :asc) },
                  has_many_children_options
       end
 

--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -79,7 +79,7 @@ module CollectiveIdea #:nodoc:
           end
 
           def nested_set_scope(options = {})
-            options = {:order => order_column}.merge(options)
+            options = {:order => { order_column => :asc }}.merge(options)
 
             where(options[:conditions]).order(options.delete(:order))
           end

--- a/lib/awesome_nested_set/model/rebuildable.rb
+++ b/lib/awesome_nested_set/model/rebuildable.rb
@@ -32,7 +32,11 @@ module CollectiveIdea
           end
 
           def order_for_rebuild
-            "#{quoted_left_column_full_name}, #{quoted_right_column_full_name}, #{primary_key}"
+            {
+              left_column_name => :asc,
+              right_column_name => :asc,
+              primary_key => :asc
+            }
           end
         end
 

--- a/lib/awesome_nested_set/model/validatable.rb
+++ b/lib/awesome_nested_set/model/validatable.rb
@@ -20,7 +20,7 @@ module CollectiveIdea
               select("#{scope_string}#{column}, COUNT(#{column}) as _count").
                 group("#{scope_string}#{column}", quoted_primary_key_column_full_name).
                 having("COUNT(#{column}) > 1").
-                order(quoted_primary_key_column_full_name).
+                order(primary_column_name => :asc).
                 first.nil?
             end
           end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -94,13 +94,13 @@ end
 class Order < ActiveRecord::Base
   acts_as_nested_set
 
-  default_scope -> { order(:name) }
+  default_scope -> { order(name: :asc) }
 end
 
 class Position < ActiveRecord::Base
   acts_as_nested_set
 
-  default_scope -> { order(:position) }
+  default_scope -> { order(position: :asc) }
 end
 
 class NoDepth < ActiveRecord::Base


### PR DESCRIPTION
Fixes #380 
#382 fixed some of these, but I still saw a lot of warnings.

With this commit the entire test suite runs on Rails 5.2.0.beta2 without any warnings.