### PR TITLE
Remove rails 5.2 warning from awesome_nested_set file

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -87,7 +87,7 @@ module CollectiveIdea #:nodoc:
           ) if acts_as_nested_set_options[ar_callback]
         end
 
-        has_many :children, -> { order(quoted_order_column_full_name) },
+        has_many :children, -> { order(Arel.sql(quoted_order_column_full_name)) },
                  has_many_children_options
       end
 


### PR DESCRIPTION
Previous commit didn't fix all issues. 