### PR TITLE
Refresh Active Record cache before updating columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ class AddNestedToCategories < ActiveRecord::Migration
     add_column :categories, :children_count, :integer
 
     # This is necessary to update :lft and :rgt columns
+    Category.reset_column_information
     Category.rebuild!
   end
 


### PR DESCRIPTION
When using a local model, we need to refresh the Active Record cache for a model prior to updating data in the database.