### PR TITLE
adds a column_name option 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.1.5
+* Add support for a custom column name that doesn't have a suffix with `_id`
+
 3.1.4
 * Add support for Rails 5.2 [John Hawthorn](https://github.com/jhawthorn) and [marocchino](https://github.com/marocchino)
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ You can pass various options to `acts_as_nested_set` macro. Configuration option
 * `right_column`: column name for right boundary data (default: rgt)
 * `depth_column`: column name for the depth data default (default: depth)
 * `scope`: restricts what is to be considered a list. Given a symbol, it'll attach `_id` (if it hasn't been already) and use that as the foreign key restriction. You can also pass an array to scope by multiple attributes. Example: `acts_as_nested_set :scope => [:notable_id, :notable_type]`
+    * `column_name`: can be passed within a Hash to `scope` to specify the exact name of the column to be used.   
+      Example: `acts_as_nested_set :scope => { :column_name => 'sfid'}`
 * `dependent`: behavior for cascading destroy. If set to :destroy, all the child objects are destroyed alongside this object by calling their destroy method. If set to :delete_all (default), all the child objects are deleted without calling their destroy method. If set to :nullify, all child objects will become orphaned and become roots themselves.
 * `counter_cache`: adds a counter cache for the number of children. defaults to false. Example: `acts_as_nested_set :counter_cache => :children_count`
 * `order_column`: on which column to do sorting, by default it is the left_column_name. Example: `acts_as_nested_set :order_column => :position`

--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -125,6 +125,10 @@ module CollectiveIdea #:nodoc:
         if options[:scope].is_a?(Symbol) && options[:scope].to_s !~ /_id$/
           options[:scope] = "#{options[:scope]}_id".intern
         end
+        
+        if options[:scope].is_a?(Hash) && options[:scope][:column_name]
+          options[:scope] = options[:scope][:column_name]
+        end
 
         class_attribute :acts_as_nested_set_options
         self.acts_as_nested_set_options = options

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -124,6 +124,10 @@ describe "AwesomeNestedSet" do
     it "scoped_appends_id" do
       expect(ScopedCategory.acts_as_nested_set_options[:scope]).to eq(:organization_id)
     end
+
+    it "sets as column if specified" do
+      expect(ScopedColumnCategory.acts_as_nested_set_options[:scope]).to eq(:organization)
+    end
   end
 
   describe "hierarchical structure" do

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -18,6 +18,11 @@ class ScopedCategory < ActiveRecord::Base
   acts_as_nested_set :scope => :organization
 end
 
+class ScopedColumnCategory < ActiveRecord::Base
+  self.table_name = 'categories'
+  acts_as_nested_set :scope => {:column_name => :organization}
+end
+
 class OrderedCategory < ActiveRecord::Base
   self.table_name = 'categories'
   acts_as_nested_set :order_column => 'name'


### PR DESCRIPTION
adds a column_name option  that can be passed with a hash to scope so that we can specify a specific name without a suffix

Some projects need to interact with columns created by other tools/frameworks which don't follow the rails convention of naming for their id, therefore a way to set a custom name is required.

One way to do it, would be to add `_id` only if a symbol is provided and not do anything if it's a string but to prevent issues with projects that use a string I've created a new option to set a custom column name.