### PR TITLE
Support for Rails 6

### DIFF
--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'
-  s.add_development_dependency 'rspec-rails', '~> 3.5.0'
+  s.add_development_dependency 'rspec-rails', '~> 3.8.0'
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'combustion', '>= 0.5.2', '< 0.5.5'
   s.add_development_dependency 'database_cleaner'


### PR DESCRIPTION
Since 'rspec-rails 3.5.0 depends on activerecord < 5.3, bundler doesn't update awesome_nested_set to 3.1.4.
So I forked and changed rspec-rails dependency from 3.5.0 to 3.8.0. It worked out.