### PR TITLE
Replace deprecated Arel::Predications.in with Arel::Predications.between

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Unreleased version
+* Fix deprecation warning "Passing a range to `#in` is deprecated".
+* [Compare to 3.2.0](https://github.com/collectiveidea/awesome_nested_set/compare/v3.2.0...master)
+
 3.2.0
 * Add support for Rails 6.0 [Stefan Andersen](https://github.com/stfnndrsn) and [Damian Legawiec](https://github.com/damianlegawiec) and [Jonathan Tapia](https://github.com/jtapia) and [Alex](https://github.com/a-ta-ta)
 * [Compare to 3.1.4](https://github.com/collectiveidea/awesome_nested_set/compare/v3.1.4...v3.2.0)

--- a/lib/awesome_nested_set/move.rb
+++ b/lib/awesome_nested_set/move.rb
@@ -41,9 +41,21 @@ module CollectiveIdea #:nodoc:
         delegate :base_class, :to => :instance_class, :prefix => :instance
 
         def where_statement(left_bound, right_bound)
-          instance_arel_table[left_column_name].in(left_bound..right_bound).
-            or(instance_arel_table[right_column_name].in(left_bound..right_bound))
+          instance_arel_table[left_column_name].between(left_bound..right_bound).
+            or(instance_arel_table[right_column_name].between(left_bound..right_bound))
         end
+
+        # Before Arel 6, there was 'in' method, which was replaced
+        # with 'between' in Arel 6 and now gives deprecation warnings
+        # in verbose mode. This is patch to support rails 4.0 (Arel 4)
+        # and 4.1 (Arel 5).
+        module LegacyWhereStatementExt
+          def where_statement(left_bound, right_bound)
+            instance_arel_table[left_column_name].in(left_bound..right_bound).
+            or(instance_arel_table[right_column_name].in(left_bound..right_bound))
+          end
+        end
+        prepend LegacyWhereStatementExt unless Arel::Predications.method_defined?(:between)
 
         def conditions(a, b, c, d)
           _conditions = case_condition_for_direction(:quoted_left_column_name) +


### PR DESCRIPTION
#353

Starting from Arel 6, `Arel::Predications.in` was replaced with `Arel::Predications.between` ([this commit](https://github.com/rails/arel/commit/f8d85cf24bca522a04edc5cc48f8716e65efb107)) and it prints deprecation warning when using verbose mode (`$VERBOSE = true`, `ruby -w`):

```
Passing a range to `#in` is deprecated. Call `#between`, instead.
```

Replaced with call to `between`.

As current version should support Rails > 4.0.0, this includes 4.0 and 4.1, which have Arel 4 and 5, if `between` method is not detected at `require` time, old implementation is used.