### PR TITLE
Don't reload in after_save callback

### DIFF
--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -200,7 +200,6 @@ module CollectiveIdea #:nodoc:
           return unless has_depth_column?
 
           in_tenacious_transaction do
-            reload
             update_depth(level)
           end
         end


### PR DESCRIPTION
AwesomeNestedSet calls reload in the after_save callback if depth is set. This can break dependencies that clear state during reload.
For example carrierwave uses reload to clear the mounters which will
result in attached files not being saved (see  #375).

Reload also doesn't seem necessary because there is no state that should
be updated for getting the depth (as far as I can see). Specs also don't break.