### PR TITLE
Add belongs_to :polymorphic key option only when used

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -98,9 +98,9 @@ module CollectiveIdea #:nodoc:
           :primary_key => primary_column_name,
           :counter_cache => acts_as_nested_set_options[:counter_cache],
           :inverse_of => (:children unless acts_as_nested_set_options[:polymorphic]),
-          :polymorphic => acts_as_nested_set_options[:polymorphic],
           :touch => acts_as_nested_set_options[:touch]
         }
+        options[:polymorphic] = true if acts_as_nested_set_options[:polymorphic]
         options[:optional] = true if ActiveRecord::VERSION::MAJOR >= 5
         belongs_to :parent, options
       end


### PR DESCRIPTION
Fixes #420 

This PR updates options passed to `belongs_to` to [make them compliant](rails/rails@2c008d9) with current Rails master 6.1.0.alpha.

I've tested against ActiveRecord 5.2.4, 6.0.2, 6.1.0.alpha and everything's working as expected.