### PR TITLE
Fix deprecation warning in tests.

### DIFF
--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -81,7 +81,7 @@ module CollectiveIdea #:nodoc:
           def nested_set_scope(options = {})
             options = {:order => { order_column_name => :asc }}.merge(options)
 
-            where(options[:conditions]).order(options.delete(:order))
+            scope_for_association.where(options[:conditions]).order(options.delete(:order))
           end
 
           def primary_key_scope(id)

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -723,9 +723,7 @@ describe "User", :type => :model do
     parent = User.first
 
     expect do
-      condition = "Chris-#{Time.current.to_f}'"
-
-      (User.find_by(name: condition) || User.create!(name: condition)).tap do |user|
+      User.where(name: "Chris-#{Time.current.to_f}").first_or_create! do |user|
         user.parent = parent
       end
     end.to change { User.count }.by 1

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -723,7 +723,9 @@ describe "User", :type => :model do
     parent = User.first
 
     expect do
-      User.where(name: "Chris-#{Time.current.to_f}").first_or_create! do |user|
+      condition = "Chris-#{Time.current.to_f}'"
+
+      (User.find_by(name: condition) || User.create!(name: condition)).tap do |user|
         user.parent = parent
       end
     end.to change { User.count }.by 1


### PR DESCRIPTION
Fixes #422 

Explicitly look for user by name, and if it doesn't exist, create it manually.
This is because when searching by `where`, we get a Rails 6.1
deprecation error, because creating from a scope will not inherit the
scope given unless explicitly set.

Note; I've tried `find_or_create_by` without success, but feel free to suggest a better solution than I've done.