### PR TITLE
Fix Ruby 2.7 warnings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleased version
 * [Compare to 3.2.1](https://github.com/collectiveidea/awesome_nested_set/compare/v3.2.1...master)
+* Fix Ruby 2.7 warning "warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call"
 
 3.2.1
 * Don't reload in after_save callback. [Petrik de Heus](https://github.com/p8)

--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -62,6 +62,7 @@ module CollectiveIdea #:nodoc:
       end
 
       private
+
       def acts_as_nested_set_define_callbacks!
         # on creation, set automatically lft and rgt to the end of the tree
         before_create  :set_default_left_and_right
@@ -88,7 +89,7 @@ module CollectiveIdea #:nodoc:
         end
 
         has_many :children, -> { order(order_column_name => :asc) },
-                 has_many_children_options
+                 **has_many_children_options
       end
 
       def acts_as_nested_set_relate_parent!
@@ -102,7 +103,7 @@ module CollectiveIdea #:nodoc:
           :touch => acts_as_nested_set_options[:touch]
         }
         options[:optional] = true if ActiveRecord::VERSION::MAJOR >= 5
-        belongs_to :parent, options
+        belongs_to :parent, **options
       end
 
       def acts_as_nested_set_default_options


### PR DESCRIPTION
Fixes #425 

Fixes the warning on Ruby 2.7

> awesome_nested_set-32f25e5c15e3/lib/awesome_nested_set/awesome_nested_set.rb:105: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
> awesome_nested_set-32f25e5c15e3/lib/awesome_nested_set/awesome_nested_set.rb:90: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call


