### PR TITLE
Fixes Rails 6.1 deprecations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 Unreleased version
+* Update for compatibility with Rails 6.1 which no longer inherits scoping
+  (Messages of the form "DEPRECATION WARNING: Class level methods will no longer inherit scoping from ...")
 * [Compare to 3.2.1](https://github.com/collectiveidea/awesome_nested_set/compare/v3.2.1...master)
 
 3.2.1

--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -103,7 +103,7 @@ module CollectiveIdea #:nodoc:
           private
 
           def scope_order_from_options(options)
-            options[:order] || { order_column_name => :asc }
+            options.fetch(:order, { order_column_name => :asc })
           end
         end # end class methods
 

--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -177,7 +177,7 @@ module CollectiveIdea #:nodoc:
           scopes = scope_column_names
           return if scopes.empty?
 
-          options[:conditions] = scopes.to_h { |attr| [attr, self[attr] ] }
+          options[:conditions] = scopes.map { |attr| [attr, self[attr] ] }.to_h
         end
 
         def without_self(scope)

--- a/lib/awesome_nested_set/move.rb
+++ b/lib/awesome_nested_set/move.rb
@@ -96,8 +96,10 @@ module CollectiveIdea #:nodoc:
 
         def lock_nodes_between!(left_bound, right_bound)
           # select the rows in the model between a and d, and apply a lock
-          instance_base_class.right_of(left_bound).left_of_right_side(right_bound).
-                              select(primary_column_name).lock(true)
+          instance_base_class.nested_set_scope.
+                              right_of(left_bound).left_of_right_side(right_bound).
+                              select(primary_column_name).
+                              lock(true)
         end
 
         def root


### PR DESCRIPTION
Fixes #422 Rails 6.1 deprecations of the form:

> DEPRECATION WARNING: Class level methods will no longer inherit scoping from `###` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `Model.unscoped`, or `Model.default_scoped` if a model has default scopes.