### PR TITLE
Ruby 2.7 keyword arguments deprecation fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Unreleased version
 * Update for compatibility with Rails 6.1 which no longer inherits scoping
   (Messages of the form "DEPRECATION WARNING: Class level methods will no longer inherit scoping from ...")
+* Fix ruby 2.7 keyword parameters deprecation warning
 * [Compare to 3.2.1](https://github.com/collectiveidea/awesome_nested_set/compare/v3.2.1...master)
 
 3.2.1

--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -88,7 +88,7 @@ module CollectiveIdea #:nodoc:
         end
 
         has_many :children, -> { order(order_column_name => :asc) },
-                 has_many_children_options
+                 **has_many_children_options
       end
 
       def acts_as_nested_set_relate_parent!
@@ -102,7 +102,7 @@ module CollectiveIdea #:nodoc:
           :touch => acts_as_nested_set_options[:touch]
         }
         options[:optional] = true if ActiveRecord::VERSION::MAJOR >= 5
-        belongs_to :parent, options
+        belongs_to :parent, **options
       end
 
       def acts_as_nested_set_default_options


### PR DESCRIPTION
> Automatic conversion of keyword arguments and positional arguments is deprecated, and conversion will be removed in Ruby 3.

https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/