### PR TITLE
Keep current scope when calling roots

### DIFF
--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -80,12 +80,7 @@ module CollectiveIdea #:nodoc:
 
           def nested_set_scope(options = {})
             order = scope_order_from_options(options)
-            default_scoped.where(options[:conditions]).order(order)
-          end
-
-          def nested_set_scope_without_default_scope(options = {})
-            order = scope_order_from_options(options)
-            unscoped.where(options[:conditions]).order(order)
+            where(options[:conditions]).order(order)
           end
 
           def primary_key_scope(id)
@@ -151,7 +146,7 @@ module CollectiveIdea #:nodoc:
         def nested_set_scope(options = {})
           add_scope_conditions_to_options(options)
 
-          self.class.base_class.nested_set_scope options
+          self.class.base_class.default_scoped.nested_set_scope options
         end
 
         # Separate an other `nested_set_scope` for unscoped model
@@ -162,7 +157,7 @@ module CollectiveIdea #:nodoc:
         def nested_set_scope_without_default_scope(options = {})
           add_scope_conditions_to_options(options)
 
-          self.class.base_class.nested_set_scope_without_default_scope options
+          self.class.base_class.unscoped.nested_set_scope options
         end
 
         def to_text

--- a/lib/awesome_nested_set/move.rb
+++ b/lib/awesome_nested_set/move.rb
@@ -96,7 +96,7 @@ module CollectiveIdea #:nodoc:
 
         def lock_nodes_between!(left_bound, right_bound)
           # select the rows in the model between a and d, and apply a lock
-          instance_base_class.nested_set_scope.
+          instance_base_class.default_scoped.nested_set_scope.
                               right_of(left_bound).left_of_right_side(right_bound).
                               select(primary_column_name).
                               lock(true)

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -140,6 +140,12 @@ describe "AwesomeNestedSet" do
       expect(Category.root).to eq(categories(:top_level))
     end
 
+    it "root_class_method with scope" do
+      categories(:top_level).update_attribute :organization_id, 999999999
+      expect(ScopedCategory.where(organization_id: 999999999).root.id).to eq(categories(:top_level).id)
+      expect(ScopedCategory.where(organization_id: 1).root).to be_nil
+    end
+
     it "root" do
       expect(categories(:child_3).root).to eq(categories(:top_level))
     end


### PR DESCRIPTION
6c5040c4c116cbff2bea69724972cff500f8334f Fixed the Rails 6.1 deprecation warnings for inherited scoping by
making scopes explicit using `Model.unscoped`, or `Model.default_scoped`.

However the `default_scoped` method added to `Model.nested_set_scope`
broke calling `roots` on `Relatable` when the nested set is scoped:

```ruby
bob = User.create!(name: 'Bob')
bobs_root = bob.categories.create(name: 'Root Category')
alice = User.create!(name: 'Alice')

# Alice has no categories so root should return nil
# Instead it returned bobs_root
assert_equal(nil, alice.categories.root)
```

Instead of using two separate class methods,
`nested_set_scope_without_default_scope` and `nested_set_scope`, that
apply the scope, we move the `default_scoped` and `unscoped` calls to
`self.class.base_class`. This fixes the `roots` scope and removes the
deprecation warnings.

Also see the Rails discussion:
https://github.com/rails/rails/issues/41066#issuecomment-757374841

Fixes: #436