### PR TITLE
Adds the ability to .move_with_index.

### DIFF
--- a/lib/awesome_nested_set/model/movable.rb
+++ b/lib/awesome_nested_set/model/movable.rb
@@ -39,6 +39,35 @@ module CollectiveIdea #:nodoc:
             move_to node, :child
           end
 
+          # Calls .move_to_child_with_index if the parent node is passed as an
+          # argument, else it calls .move_to_root_with_index and sorts at root level.
+          def move_with_index(index, node = nil)
+            if node.nil?
+              move_to_root_with_index(index)
+            else
+              move_to_child_with_index(node, index)
+            end
+          end
+
+          # Move the node to the root with specify index, or just re-order with specify
+          # index if node is already at root level.
+          def move_to_root_with_index(index)
+            # If we are already at level 0 the item should be root? => true
+            # and so we can skip moving the item to root.
+            move_to_root unless level == 0 && root?
+
+            # Sort the positioning of the item
+            # at root level based on its siblings.
+            my_position = siblings.to_a.index(self)
+            if my_position && my_position < index
+              move_to_right_of(siblings[index])
+            elsif my_position && my_position == index
+              # do nothing. already there.
+            else
+              move_to_left_of(siblings[index])
+            end
+          end
+
           # Move the node to the child of another node with specify index
           def move_to_child_with_index(node, index)
             if node.children.empty?

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -200,7 +200,7 @@ describe "User", :type => :model do
 
   it "children" do
     user = users(:top_level)
-    user.children.each {|c| expect(user.uuid).to eq(c.parent_uuid) }
+    user.children.each { |c| expect(user.uuid).to eq(c.parent_uuid) }
   end
 
   it "order_of_children" do
@@ -349,6 +349,79 @@ describe "User", :type => :model do
     expect(User.valid?).to be_truthy
   end
 
+  describe "#move_to_root_with_index" do
+    it "move to a node without child" do
+      users(:child_1).move_to_root_with_index(0)
+      users(:child_3).move_to_root_with_index(1)
+      expect(users(:child_1).parent_uuid).to eq(nil)
+      expect(users(:child_1).left).to eq(1)
+      expect(users(:child_1).right).to eq(2)
+      expect(users(:child_3).left).to eq(3)
+      expect(users(:child_3).right).to eq(4)
+      expect(User.valid?).to be_truthy
+    end
+
+    it "move to a node to the left of another root node" do
+      users(:child_1).move_to_root_with_index(0)
+      users(:child_2).move_to_root_with_index(1)
+      users(:child_3).move_to_root_with_index(2)
+
+      expect(users(:child_1).parent_uuid).to eq(nil)
+      expect(users(:child_2).parent_uuid).to eq(nil)
+      expect(users(:child_3).parent_uuid).to eq(nil)
+
+      expect(users(:child_1).left).to eq(1)
+      expect(users(:child_1).right).to eq(2)
+      expect(users(:child_2).left).to eq(3)
+      expect(users(:child_2).right).to eq(6)
+      expect(users(:child_3).left).to eq(7)
+      expect(users(:child_3).right).to eq(8)
+
+      users(:child_3).move_to_root_with_index(0)
+
+      users(:child_1).reload
+      users(:child_2).reload
+      users(:child_3).reload
+
+      expect(users(:child_3).left).to eq(1)
+      expect(users(:child_3).right).to eq(2)
+    end
+
+    it "move to a node to the right or root node" do
+      users(:child_1).move_to_root_with_index(0)
+      users(:child_2).move_to_root_with_index(1)
+      users(:child_3).move_to_root_with_index(2)
+
+      users(:child_1).reload
+      users(:child_2).reload
+      users(:child_3).reload
+
+      expect(users(:child_1).parent_uuid).to eq(nil)
+      expect(users(:child_2).parent_uuid).to eq(nil)
+      expect(users(:child_3).parent_uuid).to eq(nil)
+
+      expect(users(:child_1).left).to eq(1)
+      expect(users(:child_1).right).to eq(2)
+      expect(users(:child_2).left).to eq(3)
+      expect(users(:child_2).right).to eq(6)
+      expect(users(:child_3).left).to eq(7)
+      expect(users(:child_3).right).to eq(8)
+
+      users(:child_1).move_to_root_with_index(1)
+
+      users(:child_1).reload
+      users(:child_2).reload
+      users(:child_3).reload
+
+      expect(users(:child_1).left).to eq(5)
+      expect(users(:child_1).right).to eq(6)
+      expect(users(:child_2).left).to eq(1)
+      expect(users(:child_2).right).to eq(4)
+      expect(users(:child_3).left).to eq(7)
+      expect(users(:child_3).right).to eq(8)
+    end
+  end
+
   describe "#move_to_child_with_index" do
     it "move to a node without child" do
       users(:child_1).move_to_child_with_index(users(:child_3), 0)
@@ -383,7 +456,6 @@ describe "User", :type => :model do
       expect(users(:child_2).left).to eq(2)
       expect(users(:child_2).right).to eq(7)
     end
-
   end
 
   it "move_to_child_of_appends_to_end" do


### PR DESCRIPTION
Adds the ability to .move_with_index, encompassing sorting at both root and child levels in one method call.

**NOTE:** No tests have been written as yet, if this is something you would merge I'm happy to take the time to write the tests and update the change log, else I'll just leave this be for now.

Re-ordering Items at Root Level. #446