### PR TITLE
Make lock_nodes_between use

### DIFF
--- a/lib/awesome_nested_set/move.rb
+++ b/lib/awesome_nested_set/move.rb
@@ -96,7 +96,7 @@ module CollectiveIdea #:nodoc:
 
         def lock_nodes_between!(left_bound, right_bound)
           # select the rows in the model between a and d, and apply a lock
-          instance_base_class.default_scoped.nested_set_scope.
+          instance_base_class.unscoped.
                               right_of(left_bound).left_of_right_side(right_bound).
                               select(primary_column_name).
                               lock(true)


### PR DESCRIPTION
In 6c5040c4c116cbff2bea69724972cff500f8334f Rails warnings were fixed.

It changed the implementation of `lock_nodes_between` from:

    instance_base_class. ...

to the following:

    instance_base_class.default_scoped. ...

To check if these implementations are similar we can add a check to
`lock_nodes_between`. If we add the following line to
`lock_nodes_between` we can compare the resulting SQL for both
implementations:

    raise if instance_base_class.default_scoped.right_of(left_bound).left_of_right_side(right_bound).to_sql != instance_base_class.right_of(left_bound).left_of_right_side(right_bound).to_sql

Adding this check makes a spec fail.
Changing the check to use `unscoped` instead doesn't makes the
specs fail.

So changing the implementation to only use `unscoped` makes sure
the resulting SQL is similar to how it was before
6c5040c4c116cbff2bea69724972cff500f8334f.