### PR TITLE
Check if we should use unscoped

### DIFF
--- a/lib/awesome_nested_set/move.rb
+++ b/lib/awesome_nested_set/move.rb
@@ -96,7 +96,10 @@ module CollectiveIdea #:nodoc:
 
         def lock_nodes_between!(left_bound, right_bound)
           # select the rows in the model between a and d, and apply a lock
-          instance_base_class.default_scoped.nested_set_scope.
+          sql1 = instance_base_class.unscoped.right_of(left_bound).left_of_right_side(right_bound).to_sql
+          sql2 = instance_base_class.right_of(left_bound).left_of_right_side(right_bound).to_sql
+          raise "#{sql1} \n != \n#{sql2}"if sql1 != sql2
+          instance_base_class.unscoped.
                               right_of(left_bound).left_of_right_side(right_bound).
                               select(primary_column_name).
                               lock(true)


### PR DESCRIPTION
In 6c5040c4c116cbff2bea69724972cff500f8334f Rails warnings were fixed.

It changed the implementation of `lock_nodes_between` from:

    instance_base_class. ...

to basically the following:

    instance_base_class.default_scoped. ...

Maybe unscoped is a better solution.
This adds a check to see if the resulting SQL is similar to what it was
before 6c5040c4c116cbff2bea69724972cff500f8334f