### PR TITLE
Update README migration syntax

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 Unreleased version
 
-* Updated readme to use latest migration syntax
+* Updated README to use latest migration syntax [Justin MacCarthy](https://github.com/macarthy)
 
 * [Compare to 3.4.0](https://github.com/collectiveidea/awesome_nested_set/compare/v3.4.0...master)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Unreleased version
 
+* Updated readme to use latest migration syntax
+
 * [Compare to 3.4.0](https://github.com/collectiveidea/awesome_nested_set/compare/v3.4.0...master)
 
 3.4.0

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ class CreateCategories < ActiveRecord::Migration
     create_table :categories do |t|
       t.string :name
       t.integer :parent_id, null: true, index: true
-      t.integer :lft, null: false,  index: true
-      t.integer :rgt, null: false,  index: true
-    
+      t.integer :lft, null: false, index: true
+      t.integer :rgt, null: false, index: true
+
       # optional fields
       t.integer :depth, null: false, default: 0
       t.integer :children_count, null: false, default: 0


### PR DESCRIPTION
This modernises the migration syntax in the README, swapping out
the hash syntax and switching to `def change`.