### PR TITLE
Fix README migration syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ class CreateCategories < ActiveRecord::Migration
       t.integer :depth, null: false, default: 0
       t.integer :children_count, null: false, default: 0
       t.timestamps
-   end
+    end
+  end
 end
 ```
 


### PR DESCRIPTION
This PR fixes the migration syntax in README.

- Added missing `end`