### PR TITLE
Use https for GitHub link

### DIFF
--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email = 'info@collectiveidea.com'
   s.extra_rdoc_files = %w[README.md]
   s.files = Dir.glob('lib/**/*') + %w[MIT-LICENSE README.md CHANGELOG]
-  s.homepage = 'http://github.com/collectiveidea/awesome_nested_set'
+  s.homepage = 'https://github.com/collectiveidea/awesome_nested_set'
   s.rdoc_options = ['--main', 'README.md', '--inline-source', '--line-numbers']
   s.require_paths = ['lib']
   s.summary = 'An awesome nested set implementation for Active Record'


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/awesome_nested_set or some tools or APIs that use the gem's metadata.