### PR TITLE
Rails >= 5 should throw :abort

### DIFF
--- a/lib/awesome_nested_set/model/prunable.rb
+++ b/lib/awesome_nested_set/model/prunable.rb
@@ -47,8 +47,13 @@ module CollectiveIdea #:nodoc:
             elsif acts_as_nested_set_options[:dependent] == :restrict_with_error
               unless leaf?
                 record = self.class.human_attribute_name(:children).downcase
-                errors.add(:base, :"restrict_dependent_destroy.#{Rails::VERSION::MAJOR < 5 ? 'many' : 'has_many'}", record: record)
-                return false
+                if Rails::VERSION::MAJOR < 5
+                  errors.add(:base, :"restrict_dependent_destroy.many", record: record)
+                  return false
+                else
+                  errors.add(:base, :"restrict_dependent_destroy.has_many", record: record)
+                  throw :abort
+                end
               end
               return true
              elsif acts_as_nested_set_options[:dependent] == :nullify


### PR DESCRIPTION
With Rails >= 5 `acts_as_nested_set :dependent => :restrict_with_error`
should abort the transaction with `throw :abort` not `return false`.