### PR TITLE
Validate lft and rgt should be less then max sequence

### DIFF
--- a/lib/awesome_nested_set/model/validatable.rb
+++ b/lib/awesome_nested_set/model/validatable.rb
@@ -56,12 +56,10 @@ module CollectiveIdea
           end
 
           def left_and_right_within_range?
-            [quoted_left_column_full_name, quoted_right_column_full_name].all? do |column|
-              select("#{scope_string.chomp(", ")}").
-              group("#{scope_string.chomp(", ")}").
-              having("MAX(#{column}) > (COUNT(*) * 2)").
+            max_node_value = count * 2
+            select("#{scope_string.chomp(", ")}").
+              where("#{quoted_left_column_full_name} > :max_node_value OR #{quoted_right_column_full_name} > :max_node_value", max_node_value: max_node_value).
               count.zero?
-            end
           end
 
           private

--- a/lib/awesome_nested_set/model/validatable.rb
+++ b/lib/awesome_nested_set/model/validatable.rb
@@ -7,7 +7,10 @@ module CollectiveIdea
         module Validatable
 
           def valid?
-            left_and_rights_valid? && no_duplicates_for_columns? && all_roots_valid?
+            left_and_rights_valid? &&
+              no_duplicates_for_columns? &&
+              all_roots_valid? &&
+              left_and_right_within_range?
           end
 
           def left_and_rights_valid?
@@ -49,6 +52,15 @@ module CollectiveIdea
                 left = root.left
                 right = root.right
               end
+            end
+          end
+
+          def left_and_right_within_range?
+            [quoted_left_column_full_name, quoted_right_column_full_name].all? do |column|
+              select("#{scope_string.chomp(", ")}").
+              group("#{scope_string.chomp(", ")}").
+              having("MAX(#{column}) > (COUNT(*) * 2)").
+              count.zero?
             end
           end
 

--- a/lib/awesome_nested_set/model/validatable.rb
+++ b/lib/awesome_nested_set/model/validatable.rb
@@ -59,7 +59,7 @@ module CollectiveIdea
             max_node_value = count * 2
             select("#{scope_string.chomp(", ")}").
               where("#{quoted_left_column_full_name} > :max_node_value OR #{quoted_right_column_full_name} > :max_node_value", max_node_value: max_node_value).
-              count.zero?
+              first.nil?
           end
 
           private

--- a/lib/awesome_nested_set/model/validatable.rb
+++ b/lib/awesome_nested_set/model/validatable.rb
@@ -57,9 +57,9 @@ module CollectiveIdea
 
           def left_and_right_within_range?
             max_node_value = count * 2
-            select("#{scope_string.chomp(", ")}").
+            !select("#{scope_string.chomp(", ")}").
               where("#{quoted_left_column_full_name} > :max_node_value OR #{quoted_right_column_full_name} > :max_node_value", max_node_value: max_node_value).
-              first.nil?
+              exists?
           end
 
           private

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -715,10 +715,9 @@ describe "AwesomeNestedSet" do
   end
 
   it "valid_with_missing_intermediate_node" do
-    # Even though child_2_1 will still exist, it is a sign of a sloppy delete, not an invalid tree.
     expect(Category.valid?).to be_truthy
     Category.delete(categories(:child_2).id)
-    expect(Category.valid?).to be_truthy
+    expect(Category.valid?).to be_falsey
   end
 
   it "valid_with_overlapping_and_rights" do

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -537,10 +537,9 @@ describe "User", :type => :model do
   end
 
   it "valid_with_missing_intermediate_node" do
-    # Even though child_2_1 will still exist, it is a sign of a sloppy delete, not an invalid tree.
     expect(User.valid?).to be_truthy
     User.where(uuid: users(:child_2).uuid).delete_all
-    expect(User.valid?).to be_truthy
+    expect(User.valid?).to be_falsey
   end
 
   it "valid_with_overlapping_and_rights" do


### PR DESCRIPTION
Validate `lft` and `rgt` should be less then max sequence which is (number of records * 2)

i.e.
```
category1 = { parent_id: nil, lft: 1, rgt: 2 }
category2 = { parent_id: nil, lft: 3, rgt: 4 }
category3 = { parent_id: nil, lft: 9, rgt: 10 }
```

In above case, `Category.valid?` returns `true`, but expecting to return `false` so that it can rebuild again to correct the sequence.

Please feel free to close this PR if my changes looks invalid, as I noticed the scenario which I mentioned was considered as valid case and covered in spec that way.