### PR TITLE
Remove unused position parameter from after_move_to method

### DIFF
--- a/lib/awesome_nested_set/model/movable.rb
+++ b/lib/awesome_nested_set/model/movable.rb
@@ -107,13 +107,13 @@ module CollectiveIdea #:nodoc:
                 Move.new(target, position, self).move
                 update_counter_cache
               end
-              after_move_to(target, position)
+              after_move_to(target)
             end
           end
 
           protected
 
-          def after_move_to(target, position)
+          def after_move_to(target)
             target.reload_nested_set if target
             self.set_depth_for_self_and_descendants!
             self.reload_nested_set


### PR DESCRIPTION
Remove unused `position` parameter from `after_move_to` method