### PR TITLE
Added class name and ID for ImpossibleMove exception msg

### DIFF
--- a/lib/awesome_nested_set/move.rb
+++ b/lib/awesome_nested_set/move.rb
@@ -129,7 +129,9 @@ module CollectiveIdea #:nodoc:
 
         def prevent_impossible_move
           if !root && !instance.move_possible?(target)
-            raise ImpossibleMove, "Impossible move, target node cannot be inside moved tree."
+            error_msg = "Impossible move, target node (#{target.class.name},ID: #{target.id}) 
+              cannot be inside moved tree (#{instance.class.name},ID: #{instance.id})."
+            raise ImpossibleMove, error_msg
           end
         end
 


### PR DESCRIPTION
### Overview

It was a little bit difficult to trace the offending record when executing a background job to generate trees.