### PR TITLE
Teach `#move_to_child_with_index` to accept `:root` as a target

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 Unreleased version
+* Teach #move_to_child_of and #move_to_child_with_index to accept :root as a parameter [Micah Geisel](https://github.com/botandrose)
+* Add #roots method [Micah Geisel](https://github.com/botandrose)
 
 3.6.0
 * Support Rails 7.1 [Harshal Bhakta](https://github.com/harshalbhakta)

--- a/lib/awesome_nested_set/model/movable.rb
+++ b/lib/awesome_nested_set/model/movable.rb
@@ -45,11 +45,7 @@ module CollectiveIdea #:nodoc:
 
           # Move the node to the child of another node with specify index
           def move_to_child_with_index(node, index)
-            if node == :root
-              siblings = nested_set_scope.where(parent_id: nil)
-            else
-              siblings = node.children
-            end
+            siblings = node == :root ? roots : node.children
             if siblings.empty?
               move_to_child_of(node)
             elsif siblings.count == index

--- a/lib/awesome_nested_set/model/movable.rb
+++ b/lib/awesome_nested_set/model/movable.rb
@@ -36,7 +36,11 @@ module CollectiveIdea #:nodoc:
 
           # Move the node to the child of another node
           def move_to_child_of(node)
-            move_to node, :child
+            if node == :root
+              move_to_root
+            else
+              move_to node, :child
+            end
           end
 
           # Move the node to the child of another node with specify index
@@ -47,11 +51,7 @@ module CollectiveIdea #:nodoc:
               siblings = node.children
             end
             if siblings.empty?
-              if node == :root
-                move_to_root
-              else
-                move_to_child_of(node)
-              end
+              move_to_child_of(node)
             elsif siblings.count == index
               move_to_right_of(siblings.last)
             else

--- a/lib/awesome_nested_set/model/movable.rb
+++ b/lib/awesome_nested_set/model/movable.rb
@@ -41,7 +41,17 @@ module CollectiveIdea #:nodoc:
 
           # Move the node to the child of another node with specify index
           def move_to_child_with_index(node, index)
-            if node.children.empty?
+            if node == :root
+              move_to_root
+              my_position = self_and_siblings.index(self)
+              if my_position < index
+                move_to_right_of(self_and_siblings[index])
+              elsif my_position && my_position == index
+                # do nothing. already there.
+              else
+                move_to_left_of(self_and_siblings[index])
+              end
+            elsif node.children.empty?
               move_to_child_of(node)
             elsif node.children.count == index
               move_to_right_of(node.children.last)

--- a/lib/awesome_nested_set/model/movable.rb
+++ b/lib/awesome_nested_set/model/movable.rb
@@ -42,30 +42,29 @@ module CollectiveIdea #:nodoc:
           # Move the node to the child of another node with specify index
           def move_to_child_with_index(node, index)
             if node == :root
-              move_to_root
-              my_position = self_and_siblings.index(self)
-              if my_position < index
-                move_to_right_of(self_and_siblings[index])
-              elsif my_position && my_position == index
-                # do nothing. already there.
-              else
-                move_to_left_of(self_and_siblings[index])
-              end
-            elsif node.children.empty?
-              move_to_child_of(node)
-            elsif node.children.count == index
-              move_to_right_of(node.children.last)
+              siblings = nested_set_scope.where(parent_id: nil)
             else
-              my_position = node.children.to_a.index(self)
+              siblings = node.children
+            end
+            if siblings.empty?
+              if node == :root
+                move_to_root
+              else
+                move_to_child_of(node)
+              end
+            elsif siblings.count == index
+              move_to_right_of(siblings.last)
+            else
+              my_position = siblings.index(self)
               if my_position && my_position < index
                 # e.g. if self is at position 0 and we want to move self to position 1 then self
                 # needs to move to the *right* of the node at position 1. That's because the node
                 # that is currently at position 1 will be at position 0 after the move completes.
-                move_to_right_of(node.children[index])
+                move_to_right_of(siblings[index])
               elsif my_position && my_position == index
                 # do nothing. already there.
               else
-                move_to_left_of(node.children[index])
+                move_to_left_of(siblings[index])
               end
             end
           end

--- a/lib/awesome_nested_set/model/relatable.rb
+++ b/lib/awesome_nested_set/model/relatable.rb
@@ -93,6 +93,10 @@ module CollectiveIdea
             end
           end
 
+          def roots
+            nested_set_scope.where(parent_id: nil)
+          end
+
           protected
 
           def compute_level

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -510,6 +510,16 @@ describe "AwesomeNestedSet" do
     expect(Category.valid?).to be_truthy
   end
 
+  it "move_to_child_of :root" do
+    categories(:child_2).move_to_child_of(:root)
+    expect(categories(:child_2).parent).to be_nil
+    expect(categories(:child_2).level).to eq(0)
+    expect(categories(:child_2_1).level).to eq(1)
+    expect(categories(:child_2).left).to eq(9)
+    expect(categories(:child_2).right).to eq(12)
+    expect(Category.valid?).to be_truthy
+  end
+
   describe "#move_to_child_with_index" do
     it "move to a node without child" do
       categories(:child_1).move_to_child_with_index(categories(:child_3), 0)

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -136,6 +136,10 @@ describe "AwesomeNestedSet" do
       end
     end
 
+    it "roots" do
+      expect(categories(:child_3).roots).to eq([categories(:top_level), categories(:top_level_2)])
+    end
+
     it "root_class_method" do
       expect(Category.root).to eq(categories(:top_level))
     end

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -562,6 +562,13 @@ describe "AwesomeNestedSet" do
       expect(categories(:child_1).left).to eq(2)
       expect(categories(:child_1).right).to eq(3)
     end
+
+    it "move to top level with specified index" do
+      categories(:child_1).move_to_child_with_index(:root, 1)
+      expect(categories(:child_1).parent_id).to be_nil
+      expect(categories(:child_1).left).to eq(9)
+      expect(categories(:child_1).right).to eq(10)
+    end
   end
 
   it "move_to_child_of_appends_to_end" do


### PR DESCRIPTION
# Overview:
This PR enhances the `#move_to_child_with_index` method to accept `:root` as a valid parent:

```ruby
categories(:child_1).move_to_child_with_index(:root, 1)
```

# Motivation:
The motivation was pairing ANS with a JavaScript drag-and-drop tree reordering library, and needing to persist the moves made to the database. The `#move_to_child_with_index` API was perfect for this, except it couldn't handle moves made to the top-level. This has been noted before in https://github.com/collectiveidea/awesome_nested_set/issues/446

# Questions:
Does this look like a reasonable addition to ANS? Is this the right API design? Would passing `nil` instead of `:root` be more consistent with the rest of the API? Or perhaps it should be a new method entirely, like https://github.com/collectiveidea/awesome_nested_set/pull/447 ?

# Future work:
If this is the right API design, I'd like to refactor out the duplication in `#move_to_child_with_index`. Also, I'd like to add a few more tests.

What do you think?