### PR TITLE
Get CI passing on Rails main again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,14 @@ jobs:
           - ruby: '3.0'
             gemfile: rails_5_2
 
-          # Rails 7 requires Ruby 2.7 or higher
+          # Rails 8 requires Ruby 3.1 or higher
           - ruby: '2.6'
+            gemfile: rails_main
+
+          - ruby: '2.7'
+            gemfile: rails_main
+
+          - ruby: '3.0'
             gemfile: rails_main
 
           - ruby: '2.6'
@@ -89,13 +95,19 @@ jobs:
           - ruby: '3.0'
             gemfile: rails_5_2
 
-          # Rails 7 requires Ruby 2.7 or higher
+          # Rails 8 requires Ruby 3.1 or higher
           - ruby: '2.6'
+            gemfile: rails_main
+
+          - ruby: '2.7'
+            gemfile: rails_main
+
+          - ruby: '3.0'
             gemfile: rails_main
 
           - ruby: '2.6'
             gemfile: rails_7_0
-            
+
           - ruby: '2.6'
             gemfile: rails_7_1
     env:
@@ -158,15 +170,21 @@ jobs:
           - ruby: '3.0'
             gemfile: rails_5_2
 
-          # Rails 7 requires Ruby 2.7 or higher
-          - ruby: '2.6'
-            gemfile: rails_7_0
-          
-          - ruby: '2.6'
-            gemfile: rails_7_1
-
+          # Rails 8 requires Ruby 3.1 or higher
           - ruby: '2.6'
             gemfile: rails_main
+
+          - ruby: '2.7'
+            gemfile: rails_main
+
+          - ruby: '3.0'
+            gemfile: rails_main
+
+          - ruby: '2.6'
+            gemfile: rails_7_0
+
+          - ruby: '2.6'
+            gemfile: rails_7_1
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true

--- a/Appraisals
+++ b/Appraisals
@@ -6,4 +6,5 @@ end
 
 appraise "rails-main" do
   gem "rails", github: "rails/rails", branch: "main"
+  gem "rspec-rails", "~> 6.0.2"
 end

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", github: "rails/rails", branch: "main"
+gem "rspec-rails", "~> 6.0.2"
 
 platforms :ruby do
   gem "sqlite3"

--- a/spec/awesome_nested_set_spec.rb
+++ b/spec/awesome_nested_set_spec.rb
@@ -1225,13 +1225,13 @@ describe "AwesomeNestedSet" do
     it "should sort by custom sort column" do
       expect(OrderedCategory.acts_as_nested_set_options[:order_column]).to eq('name')
       expect(OrderedCategory.order_column_name).to eq('name')
-      expect(OrderedCategory.first.children.explain).to include('ORDER BY name')
+      expect(OrderedCategory.first.children.explain.inspect).to include('ORDER BY name')
     end
 
     it "should sort by custom hash sort" do
       expect(HashOrderedCategory.acts_as_nested_set_options[:order_column]).to eq({ :name => :desc })
       expect(HashOrderedCategory.order_column_name).to eq({ :name => :desc })
-      expect(HashOrderedCategory.first.children.explain).to include(
+      expect(HashOrderedCategory.first.children.explain.inspect).to include(
         "ORDER BY #{HashOrderedCategory.quoted_table_name}.#{HashOrderedCategory.connection.quote_column_name(:name)} DESC"
       )
     end


### PR DESCRIPTION
Fixes:
1. Require Ruby >= 3.1
2. Require rspec-rails >= 6.0.2
3. Call `#inspect` on `Relation#explain` to ensure we have a string