### PR TITLE
Add tests with Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         gemfile:
           - rails_5_2
           - rails_6_0
@@ -25,6 +25,15 @@ jobs:
           - rails_7_2
           - rails_main
         exclude:
+          - ruby: '3.3'
+            gemfile: rails_6_1
+
+          - ruby: '3.3'
+            gemfile: rails_6_0
+
+          - ruby: '3.3'
+            gemfile: rails_5_2
+
           - ruby: '3.2'
             gemfile: rails_6_0
 
@@ -37,7 +46,7 @@ jobs:
           - ruby: '3.0'
             gemfile: rails_5_2
 
-          # Rails 7.2 requires Ruby 3.1 or higher
+          # Rails 8.0 requires Ruby 3.2 or higher
           - ruby: '2.6'
             gemfile: rails_main
 
@@ -45,6 +54,9 @@ jobs:
             gemfile: rails_main
 
           - ruby: '3.0'
+            gemfile: rails_main
+
+          - ruby: '3.1'
             gemfile: rails_main
 
           - ruby: '2.6'
@@ -86,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         gemfile:
           - rails_5_2
           - rails_6_0
@@ -96,6 +108,15 @@ jobs:
           - rails_7_2
           - rails_main
         exclude:
+          - ruby: '3.3'
+            gemfile: rails_6_1
+
+          - ruby: '3.3'
+            gemfile: rails_6_0
+
+          - ruby: '3.3'
+            gemfile: rails_5_2
+
           - ruby: '3.2'
             gemfile: rails_6_0
 
@@ -108,7 +129,7 @@ jobs:
           - ruby: '3.0'
             gemfile: rails_5_2
 
-          # Rails 8 requires Ruby 3.1 or higher
+          # Rails 8 requires Ruby 3.2 or higher
           - ruby: '2.6'
             gemfile: rails_main
 
@@ -116,6 +137,9 @@ jobs:
             gemfile: rails_main
 
           - ruby: '3.0'
+            gemfile: rails_main
+
+          - ruby: '3.1'
             gemfile: rails_main
 
           - ruby: '2.6'
@@ -172,7 +196,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         gemfile:
           - rails_5_2
           - rails_6_0
@@ -182,6 +206,15 @@ jobs:
           - rails_7_2
           - rails_main
         exclude:
+          - ruby: '3.3'
+            gemfile: rails_6_1
+
+          - ruby: '3.3'
+            gemfile: rails_6_0
+
+          - ruby: '3.3'
+            gemfile: rails_5_2
+
           - ruby: '3.2'
             gemfile: rails_6_0
 


### PR DESCRIPTION
Ruby 3.3.0 was released on 2023-12-25 (10 month ago).

https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

- cf. #484

Also we can remove testing with Ruby 3.1 on rails main as Rails 8 dropped Ruby 3.1 support: https://rubyonrails.org/2024/9/27/this-week-in-rails or https://github.com/rails/rails/pull/53041