### PR TITLE
Add support for activerecord 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'head']
         gemfile:
           - rails_5_2
           - rails_6_0
@@ -23,8 +23,27 @@ jobs:
           - rails_7_0
           - rails_7_1
           - rails_7_2
+          - rails_8_0
           - rails_main
         exclude:
+          - ruby: 'head'
+            gemfile: rails_6_1
+
+          - ruby: 'head'
+            gemfile: rails_6_0
+
+          - ruby: 'head'
+            gemfile: rails_5_2
+
+          - ruby: '3.3'
+            gemfile: rails_6_1
+
+          - ruby: '3.3'
+            gemfile: rails_6_0
+
+          - ruby: '3.3'
+            gemfile: rails_5_2
+
           - ruby: '3.2'
             gemfile: rails_6_0
 
@@ -37,7 +56,7 @@ jobs:
           - ruby: '3.0'
             gemfile: rails_5_2
 
-          # Rails 7.2 requires Ruby 3.1 or higher
+          # Rails 8.1 requires Ruby 3.2 or higher
           - ruby: '2.6'
             gemfile: rails_main
 
@@ -45,6 +64,9 @@ jobs:
             gemfile: rails_main
 
           - ruby: '3.0'
+            gemfile: rails_main
+
+          - ruby: '3.1'
             gemfile: rails_main
 
           - ruby: '2.6'
@@ -61,6 +83,19 @@ jobs:
 
           - ruby: '3.0'
             gemfile: rails_7_2
+
+          - ruby: '2.6'
+            gemfile: rails_8_0
+
+          - ruby: '2.7'
+            gemfile: rails_8_0
+
+          - ruby: '3.0'
+            gemfile: rails_8_0
+
+          - ruby: '3.1'
+            gemfile: rails_8_0
+
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true
@@ -86,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'head']
         gemfile:
           - rails_5_2
           - rails_6_0
@@ -94,8 +129,27 @@ jobs:
           - rails_7_0
           - rails_7_1
           - rails_7_2
+          - rails_8_0
           - rails_main
         exclude:
+          - ruby: 'head'
+            gemfile: rails_6_1
+
+          - ruby: 'head'
+            gemfile: rails_6_0
+
+          - ruby: 'head'
+            gemfile: rails_5_2
+
+          - ruby: '3.3'
+            gemfile: rails_6_1
+
+          - ruby: '3.3'
+            gemfile: rails_6_0
+
+          - ruby: '3.3'
+            gemfile: rails_5_2
+
           - ruby: '3.2'
             gemfile: rails_6_0
 
@@ -108,7 +162,7 @@ jobs:
           - ruby: '3.0'
             gemfile: rails_5_2
 
-          # Rails 8 requires Ruby 3.1 or higher
+          # Rails 8.1 requires Ruby 3.2 or higher
           - ruby: '2.6'
             gemfile: rails_main
 
@@ -116,6 +170,9 @@ jobs:
             gemfile: rails_main
 
           - ruby: '3.0'
+            gemfile: rails_main
+
+          - ruby: '3.1'
             gemfile: rails_main
 
           - ruby: '2.6'
@@ -132,6 +189,19 @@ jobs:
 
           - ruby: '3.0'
             gemfile: rails_7_2
+
+          - ruby: '2.6'
+            gemfile: rails_8_0
+
+          - ruby: '2.7'
+            gemfile: rails_8_0
+
+          - ruby: '3.0'
+            gemfile: rails_8_0
+
+          - ruby: '3.1'
+            gemfile: rails_8_0
+
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true
@@ -172,7 +242,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'head']
         gemfile:
           - rails_5_2
           - rails_6_0
@@ -180,8 +250,27 @@ jobs:
           - rails_7_0
           - rails_7_1
           - rails_7_2
+          - rails_8_0
           - rails_main
         exclude:
+          - ruby: 'head'
+            gemfile: rails_6_1
+
+          - ruby: 'head'
+            gemfile: rails_6_0
+
+          - ruby: 'head'
+            gemfile: rails_5_2
+
+          - ruby: '3.3'
+            gemfile: rails_6_1
+
+          - ruby: '3.3'
+            gemfile: rails_6_0
+
+          - ruby: '3.3'
+            gemfile: rails_5_2
+
           - ruby: '3.2'
             gemfile: rails_6_0
 
@@ -194,7 +283,7 @@ jobs:
           - ruby: '3.0'
             gemfile: rails_5_2
 
-          # Rails 8 requires Ruby 3.1 or higher
+          # Rails 8.1 requires Ruby 3.2 or higher
           - ruby: '2.6'
             gemfile: rails_main
 
@@ -202,6 +291,9 @@ jobs:
             gemfile: rails_main
 
           - ruby: '3.0'
+            gemfile: rails_main
+
+          - ruby: '3.1'
             gemfile: rails_main
 
           - ruby: '2.6'
@@ -218,6 +310,18 @@ jobs:
 
           - ruby: '3.0'
             gemfile: rails_7_2
+
+          - ruby: '2.6'
+            gemfile: rails_8_0
+
+          - ruby: '2.7'
+            gemfile: rails_8_0
+
+          - ruby: '3.0'
+            gemfile: rails_8_0
+
+          - ruby: '3.1'
+            gemfile: rails_8_0
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true

--- a/Appraisals
+++ b/Appraisals
@@ -4,14 +4,20 @@
   "6_1" => "6.1.0",
   "7_0" => "7.0.0",
   "7_1" => "7.1.0",
-  "7_2" => "7.2.0"
+  "7_2" => "7.2.0",
+  "8_0" => "8.0.0.rc1"
 }.each do |rails, version|
   appraise "rails-#{rails}" do
     gem "rails", "~> #{version}"
+    if rails == "7_0"
+      gem "base64"
+      gem "bigdecimal"
+      gem "drb"
+      gem "mutex_m"
+    end
   end
 end
 
 appraise "rails-main" do
   gem "rails", github: "rails/rails", branch: "main"
-  gem "rspec-rails", "~> 6.0.2"
 end

--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -18,14 +18,14 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 8.0'
+  s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 8.1'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'
   s.add_development_dependency 'rake', '~> 13'
-  s.add_development_dependency 'rspec-rails', '>= 4.0.0', '<= 6.2'
+  s.add_development_dependency 'rspec-rails', '>= 4.0.0', '< 8.0'
 
   s.cert_chain = [File.expand_path('certs/parndt.pem', __dir__)]
   if $PROGRAM_NAME =~ /gem\z/ && ARGV.include?('build') && ARGV.include?(__FILE__)

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -5,9 +5,9 @@ source "https://rubygems.org"
 gem "rails", "~> 7.2.0"
 
 platforms :ruby do
+  gem "sqlite3"
   gem "mysql2", "< 1.0.0"
   gem "pg", "< 2.0.0"
-  gem "sqlite3"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -2,14 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.0.0"
-gem "base64"
-gem "bigdecimal"
-gem "drb"
-gem "mutex_m"
+gem "rails", "~> 8.0.0.rc1"
 
 platforms :ruby do
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3"
   gem "mysql2", "< 1.0.0"
   gem "pg", "< 2.0.0"
 end

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", github: "rails/rails", branch: "main"
-gem "rspec-rails", "~> 6.0.2"
 
 platforms :ruby do
   gem "sqlite3"


### PR DESCRIPTION
This allows us to use activerecord 8.0.

In addition,

- Adds Ruby 3.3 and head (3.4 as of writing) to all test matrices (only with Rails 7.0, 7.1, 8.0, and edge (i.e., 8.1))
- Adds Ruby 3.2 to MySQL test matrix
- Tweaks `mutex_m` / `bigdecimal` gems only in Rails 7.0.x only on testing
- Allows us to use rspec-rails 7.x, which is officially for Rails 7.0+

## Checklist

- [x] Test on my forked repo in advance of approving worlflow: https://github.com/tnir/awesome_nested_set/actions/runs/11425291192