### PR TITLE
Trusted Publishing

### DIFF
--- a/.github/workflows/publish_gem.yml
+++ b/.github/workflows/publish_gem.yml
@@ -1,0 +1,28 @@
+name: Publish Gem
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  push:
+    if: github.repository == 'collectiveidea/awesome_nested_set'
+    runs-on: ubuntu-latest
+    environment: publishing
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      # Set up
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 Unreleased version
 
+3.8.0 
+* Support Rails 8.0 [Takuya N](https://github.com/collectiveidea/awesome_nested_set/pull/487)
+* Enable Rubygems Trusted Publishing
+
 3.7.0
 * Teach #move_to_child_of and #move_to_child_with_index to accept :root as a parameter [Micah Geisel](https://github.com/botandrose)
 * Add #roots method [Micah Geisel](https://github.com/botandrose)

--- a/lib/awesome_nested_set/version.rb
+++ b/lib/awesome_nested_set/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AwesomeNestedSet
-  VERSION = '3.7.0' unless defined?(::AwesomeNestedSet::VERSION)
+  VERSION = '3.8.0' unless defined?(::AwesomeNestedSet::VERSION)
 end


### PR DESCRIPTION
Enable Rubygems Trusted Publishing while I'm sitting at Hack Day at RubyConf. 

No reason not to, and works on other projects well.

Any Release with tag starting with `v` will trigger it and should Just Work™.
