### PR TITLE
Fix Rails 7.1 fixture_path deprecation warning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Unreleased version
+* Fix Rails 7.1 deprecation warning for singular fixture_path in test config
 
 3.9.0
 * Support Rails 8.1 [Ulisses Caon](https://github.com/collectiveidea/awesome_nested_set/pull/495)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,11 @@ require 'action_controller'
 require 'rspec/rails'
 require 'database_cleaner'
 RSpec.configure do |config|
-  config.fixture_path = "#{plugin_test_dir}/fixtures"
+  if config.respond_to?(:fixture_paths=)
+    config.fixture_paths = ["#{plugin_test_dir}/fixtures"]
+  else
+    config.fixture_path = "#{plugin_test_dir}/fixtures"
+  end
   config.use_transactional_fixtures = true
   config.after(:suite) do
     unless /sqlite/ === ENV['DB']


### PR DESCRIPTION
On a clean checkout, when running `bundle exec spec` I got the following:

> Deprecation Warnings:
> 
> Rails 7.1 has deprecated the singular fixture_path in favour of an array.You should migrate to plural:

> If you need more of the backtrace for any of these deprecations to
> identify where to make the necessary changes, you can configure
> `config.raise_errors_for_deprecations!`, and it will turn the
> deprecation warnings into errors, giving you the full backtrace.
> 
> 1 deprecation warning total


I made `fixture_paths=` / fall back to `fixture_path=`. `rspec` has officially made this change [upstream](https://github.com/brianjbayer/random_thoughts_api/pull/106), so presumably this warning will persist and/or this functionality will break at some point in the future?