### PR TITLE
Fix frozen string literal warning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Unreleased version
+* Fix frozen string literal warning in scope_for_rebuild on Ruby 4.0+
 
 3.9.0
 * Support Rails 8.1 [Ulisses Caon](https://github.com/collectiveidea/awesome_nested_set/pull/495)

--- a/lib/awesome_nested_set/model/rebuildable.rb
+++ b/lib/awesome_nested_set/model/rebuildable.rb
@@ -21,11 +21,11 @@ module CollectiveIdea
 
             if acts_as_nested_set_options[:scope]
               scope = proc {|node|
-                scope_column_names.inject("") {|str, column_name|
+                scope_column_names.map {|column_name|
                   column_value = node.send(column_name)
                   cond = column_value.nil? ? "IS NULL" : "= #{connection.quote(column_value)}"
-                  str << "AND #{connection.quote_column_name(column_name)} #{cond} "
-                }
+                  "AND #{connection.quote_column_name(column_name)} #{cond} "
+                }.join
               }
             end
             scope


### PR DESCRIPTION
When I run `bin/rails test` (in a rails8/ruby4 project) I get a ton of warnings in the logs due to awesome_nested_set having some deprecations:

> /home/vscode/.local/share/mise/installs/ruby/4.0.2/lib/ruby/gems/4.0.0/gems/awesome_nested_set-3.9.0/lib/awesome_nested_set/model/rebuildable.rb:27: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)

The change was to replace `inject("") { |str, ...| str << ... }` with `map { ... }.join`.  